### PR TITLE
add request too large error

### DIFF
--- a/error.go
+++ b/error.go
@@ -16,6 +16,8 @@ const (
 	ErrTypePermission ErrType = "permission_error"
 	// ErrTypeNotFound The requested resource was not found.
 	ErrTypeNotFound ErrType = "not_found_error"
+	// ErrTypeTooLarge Request exceeds the maximum allowed number of bytes.
+	ErrTypeTooLarge ErrType = "request_too_large"
 	// ErrTypeRateLimit Your account has hit a rate limit.
 	ErrTypeRateLimit ErrType = "rate_limit_error"
 	// ErrTypeApi An unexpected error has occurred internal to Anthropic's systems.
@@ -48,6 +50,10 @@ func (e *APIError) IsPermissionErr() bool {
 
 func (e *APIError) IsNotFoundErr() bool {
 	return e.Type == ErrTypeNotFound
+}
+
+func (e *APIError) IsTooLargeErr() bool {
+	return e.Type == ErrTypeTooLarge
 }
 
 func (e *APIError) IsRateLimitErr() bool {


### PR DESCRIPTION
In the Anthropic errors documentation page, there is a request too large error 413. https://docs.anthropic.com/en/api/errors

This PR adds support for this error into `errors.go`.