### PR TITLE
Update output in the examples to refer to the object and not the pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
         }
 		return
 	}
-	fmt.Println(resp.Content[0].Text)
+	fmt.Println(*resp.Content[0].Text)
 }
 ```
 
@@ -93,7 +93,7 @@ func main() {
         }
 		return
 	}
-	fmt.Println(resp.Content[0].Text)
+	fmt.Println(*resp.Content[0].Text)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
         }
 		return
 	}
-	fmt.Println(*resp.Content[0].Text)
+	fmt.Println(resp.Content[0].GetText())
 }
 ```
 
@@ -93,7 +93,7 @@ func main() {
         }
 		return
 	}
-	fmt.Println(*resp.Content[0].Text)
+	fmt.Println(resp.Content[0].GetText())
 }
 ```
 
@@ -244,4 +244,3 @@ func main() {
 The following project had particular influence on go-anthropic is design.
 
 - [sashabaranov/go-openai](https://github.com/sashabaranov/go-openai)
-


### PR DESCRIPTION
When using the examples as-is I would get a result like 0x56366332 instead of the value to which the pointer points. This fixes that.