### PR TITLE
Multi system message constructor, and types for model + chat roles.

### DIFF
--- a/common.go
+++ b/common.go
@@ -17,5 +17,4 @@ type ChatRole string
 const (
 	RoleUser      ChatRole = "user"
 	RoleAssistant ChatRole = "assistant"
-	
 )

--- a/common.go
+++ b/common.go
@@ -1,16 +1,21 @@
 package anthropic
 
-const (
-	ModelClaudeInstant1Dot2        = "claude-instant-1.2"
-	ModelClaude2Dot0               = "claude-2.0"
-	ModelClaude2Dot1               = "claude-2.1"
-	ModelClaude3Opus20240229       = "claude-3-opus-20240229"
-	ModelClaude3Sonnet20240229     = "claude-3-sonnet-20240229"
-	ModelClaude3Dot5Sonnet20240620 = "claude-3-5-sonnet-20240620"
-	ModelClaude3Haiku20240307      = "claude-3-haiku-20240307"
-)
+type Model string
 
 const (
-	RoleUser      = "user"
-	RoleAssistant = "assistant"
+	ModelClaudeInstant1Dot2        Model = "claude-instant-1.2"
+	ModelClaude2Dot0               Model = "claude-2.0"
+	ModelClaude2Dot1               Model = "claude-2.1"
+	ModelClaude3Opus20240229       Model = "claude-3-opus-20240229"
+	ModelClaude3Sonnet20240229     Model = "claude-3-sonnet-20240229"
+	ModelClaude3Dot5Sonnet20240620 Model = "claude-3-5-sonnet-20240620"
+	ModelClaude3Haiku20240307      Model = "claude-3-haiku-20240307"
+)
+
+type ChatRole string
+
+const (
+	RoleUser      ChatRole = "user"
+	RoleAssistant ChatRole = "assistant"
+	
 )

--- a/complete.go
+++ b/complete.go
@@ -6,7 +6,7 @@ import (
 )
 
 type CompleteRequest struct {
-	Model             string `json:"model"`
+	Model             Model  `json:"model"`
 	Prompt            string `json:"prompt"`
 	MaxTokensToSample int    `json:"max_tokens_to_sample"`
 
@@ -38,7 +38,7 @@ type CompleteResponse struct {
 	Completion string `json:"completion"`
 	// possible values are: stop_sequence、max_tokens、null
 	StopReason string `json:"stop_reason"`
-	Model      string `json:"model"`
+	Model      Model  `json:"model"`
 }
 
 func (c *Client) CreateComplete(ctx context.Context, request CompleteRequest) (response CompleteResponse, err error) {

--- a/message.go
+++ b/message.go
@@ -87,6 +87,13 @@ type MessageSystemPart struct {
 	CacheControl *MessageCacheControl `json:"cache_control,omitempty"`
 }
 
+func NewSystemMessagePart(text string) MessageSystemPart {
+	return MessageSystemPart{
+		Type: "text",
+		Text: text,
+	}
+}
+
 type Message struct {
 	Role    ChatRole         `json:"role"`
 	Content []MessageContent `json:"content"`

--- a/message.go
+++ b/message.go
@@ -88,11 +88,11 @@ type MessageSystemPart struct {
 }
 
 func NewMultiSystemMessages(texts ...string) []MessageSystemPart {
-	var result []MessageSystemPart
+	var systemParts []MessageSystemPart
 	for _, text := range texts {
-		result = append(result, NewSystemMessagePart(text))
+		systemParts = append(systemParts, NewSystemMessagePart(text))
 	}
-	return result
+	return systemParts
 }
 
 func NewSystemMessagePart(text string) MessageSystemPart {
@@ -184,12 +184,8 @@ func NewToolResultMessageContent(toolUseID, content string, isError bool) Messag
 
 func NewToolUseMessageContent(toolUseID, name string, input json.RawMessage) MessageContent {
 	return MessageContent{
-		Type: MessagesContentTypeToolUse,
-		MessageContentToolUse: &MessageContentToolUse{
-			ID:    toolUseID,
-			Name:  name,
-			Input: input,
-		},
+		Type:                  MessagesContentTypeToolUse,
+		MessageContentToolUse: NewMessageContentToolUse(toolUseID, name, input),
 	}
 }
 
@@ -267,10 +263,26 @@ type MessageContentImageSource struct {
 	Data      any    `json:"data"`
 }
 
+func NewMessageContentImageSource(imageSourceType, mediaType string, data any) MessageContentImageSource {
+	return MessageContentImageSource{
+		Type:      imageSourceType,
+		MediaType: mediaType,
+		Data:      data,
+	}
+}
+
 type MessageContentToolUse struct {
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
+}
+
+func NewMessageContentToolUse(toolUseId, name string, input json.RawMessage) *MessageContentToolUse {
+	return &MessageContentToolUse{
+		ID:    toolUseId,
+		Name:  name,
+		Input: input,
+	}
 }
 
 func (c *MessageContentToolUse) UnmarshalInput(v any) error {

--- a/message.go
+++ b/message.go
@@ -87,6 +87,14 @@ type MessageSystemPart struct {
 	CacheControl *MessageCacheControl `json:"cache_control,omitempty"`
 }
 
+func NewMultiSystemMessages(texts ...string) []MessageSystemPart {
+	var result []MessageSystemPart
+	for _, text := range texts {
+		result = append(result, NewSystemMessagePart(text))
+	}
+	return result
+}
+
 func NewSystemMessagePart(text string) MessageSystemPart {
 	return MessageSystemPart{
 		Type: "text",

--- a/message.go
+++ b/message.go
@@ -34,7 +34,7 @@ const (
 )
 
 type MessagesRequest struct {
-	Model     string    `json:"model"`
+	Model     Model     `json:"model"`
 	Messages  []Message `json:"messages"`
 	MaxTokens int       `json:"max_tokens"`
 
@@ -88,7 +88,7 @@ type MessageSystemPart struct {
 }
 
 type Message struct {
-	Role    string           `json:"role"`
+	Role    ChatRole         `json:"role"`
 	Content []MessageContent `json:"content"`
 }
 
@@ -267,9 +267,9 @@ type MessagesResponse struct {
 
 	ID           string               `json:"id"`
 	Type         MessagesResponseType `json:"type"`
-	Role         string               `json:"role"`
+	Role         ChatRole             `json:"role"`
 	Content      []MessageContent     `json:"content"`
-	Model        string               `json:"model"`
+	Model        Model                `json:"model"`
 	StopReason   MessagesStopReason   `json:"stop_reason"`
 	StopSequence string               `json:"stop_sequence"`
 	Usage        MessagesUsage        `json:"usage"`

--- a/message_test.go
+++ b/message_test.go
@@ -47,18 +47,79 @@ func TestMessages(t *testing.T) {
 		anthropic.WithEmptyMessagesLimit(100),
 		anthropic.WithHTTPClient(http.DefaultClient),
 	)
-	resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-		Model: anthropic.ModelClaudeInstant1Dot2,
-		Messages: []anthropic.Message{
-			anthropic.NewUserTextMessage("What is your name?"),
-		},
-		MaxTokens: 1000,
-	})
-	if err != nil {
-		t.Fatalf("CreateMessages error: %v", err)
-	}
 
-	t.Logf("CreateMessages resp: %+v", resp)
+	t.Run("create messages success", func(t *testing.T) {
+		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
+			Model: anthropic.ModelClaudeInstant1Dot2,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens: 1000,
+		})
+		if err != nil {
+			t.Fatalf("CreateMessages error: %v", err)
+		}
+
+		t.Logf("CreateMessages resp: %+v", resp)
+	})
+
+	t.Run("create messages success with single system message", func(t *testing.T) {
+		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
+			Model: anthropic.ModelClaudeInstant1Dot2,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens: 1000,
+			System:    "test system message",
+		})
+		if err != nil {
+			t.Fatalf("CreateMessages error: %v", err)
+		}
+
+		t.Logf("CreateMessages resp: %+v", resp)
+	})
+
+	t.Run("create messages success with single multi-system message", func(t *testing.T) {
+		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
+			Model: anthropic.ModelClaudeInstant1Dot2,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens:   1000,
+			MultiSystem: anthropic.NewMultiSystemMessages("test single multi-system message"),
+		})
+		if err != nil {
+			t.Fatalf("CreateMessages error: %v", err)
+		}
+
+		t.Logf("CreateMessages resp: %+v", resp)
+	})
+
+	t.Run("create messages success with multi-system messages", func(t *testing.T) {
+		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
+			Model: anthropic.ModelClaudeInstant1Dot2,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens: 1000,
+			MultiSystem: anthropic.NewMultiSystemMessages(
+				"test multi-system messages",
+				"here",
+				"are",
+				"some",
+				"more",
+				"messages",
+				"for",
+				"testing",
+			),
+		})
+		if err != nil {
+			t.Fatalf("CreateMessages error: %v", err)
+		}
+
+		t.Logf("CreateMessages resp: %+v", resp)
+	})
+
 }
 
 func TestNewUserTextMessage(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -312,12 +312,13 @@ func TestMessagesVision(t *testing.T) {
 			{
 				Role: anthropic.RoleUser,
 				Content: []anthropic.MessageContent{
+					anthropic.NewImageMessageContent(anthropic.NewMessageContentImageSource("base64", imageMediaType, imageData)),
 					anthropic.NewImageMessageContent(anthropic.MessageContentImageSource{
 						Type:      "base64",
 						MediaType: imageMediaType,
 						Data:      imageData,
 					}),
-					anthropic.NewTextMessageContent("Describe this image."),
+					anthropic.NewTextMessageContent("Describe these images."),
 				},
 			},
 		},

--- a/ratelimit_headers.go
+++ b/ratelimit_headers.go
@@ -25,20 +25,23 @@ type RateLimitHeaders struct {
 
 func newRateLimitHeaders(h http.Header) (RateLimitHeaders, error) {
 	errs := []error{}
+	collectError := func(err error) {
+		errs = append(errs, err)
+	}
 
 	requestsLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-limit"))
-	errs = append(errs, err)
+	collectError(err)
 	requestsRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-remaining"))
-	errs = append(errs, err)
+	collectError(err)
 	requestsReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-requests-reset"))
-	errs = append(errs, err)
+	collectError(err)
 
 	tokensLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-limit"))
-	errs = append(errs, err)
+	collectError(err)
 	tokensRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-remaining"))
-	errs = append(errs, err)
+	collectError(err)
 	tokensReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-tokens-reset"))
-	errs = append(errs, err)
+	collectError(err)
 
 	retryAfter, err := strconv.Atoi(h.Get("retry-after"))
 	if err != nil {

--- a/ratelimit_headers.go
+++ b/ratelimit_headers.go
@@ -25,23 +25,20 @@ type RateLimitHeaders struct {
 
 func newRateLimitHeaders(h http.Header) (RateLimitHeaders, error) {
 	errs := []error{}
-	collectError := func(err error) {
-		errs = append(errs, err)
-	}
 
 	requestsLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-limit"))
-	collectError(err)
+	errs = append(errs, err)
 	requestsRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-remaining"))
-	collectError(err)
+	errs = append(errs, err)
 	requestsReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-requests-reset"))
-	collectError(err)
+	errs = append(errs, err)
 
 	tokensLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-limit"))
-	collectError(err)
+	errs = append(errs, err)
 	tokensRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-remaining"))
-	collectError(err)
+	errs = append(errs, err)
 	tokensReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-tokens-reset"))
-	collectError(err)
+	errs = append(errs, err)
 
 	retryAfter, err := strconv.Atoi(h.Get("retry-after"))
 	if err != nil {


### PR DESCRIPTION
While using this library, I found myself using `NewXXXTextMessage`, `NewUserImageMessage` a lot, but wondered why there was no similar constructor for multi-system messages.
This PR adds this functionality with a test.

This PR also adds a type for model names and chat roles, since both of them were plain strings. It's just a string, so it doesn't offer any "protection", but is nice for sanity checking while writing code / reasoning about correctness.