### PR TITLE
rate limit headers for streaming messages

### DIFF
--- a/message_stream.go
+++ b/message_stream.go
@@ -163,6 +163,7 @@ func (c *Client) CreateMessagesStream(ctx context.Context, request MessagesStrea
 					request.OnMessageStart(d)
 				}
 				response = d.Message
+				response.SetHeader(resp.Header)
 				continue
 			case MessagesEventContentBlockStart:
 				var d MessagesEventContentBlockStartData

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -64,6 +64,12 @@ func TestMessagesStream(t *testing.T) {
 		t.Fatalf("CreateMessagesStream content not match expected: %s, got: %s", expectedContent, resp.GetFirstContentText())
 	}
 
+	headers, err := resp.GetRateLimitHeaders()
+	if err != nil {
+		t.Fatalf("CreateMessagesStream GetRateLimitHeaders error: %s", err)
+	}
+	t.Logf("CreateMessagesStream rate limit headers: %+v", headers)
+
 	t.Logf("CreateMessagesStream resp: %+v", resp)
 }
 
@@ -300,6 +306,14 @@ func handlerMessagesStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
+
+	w.Header().Set("anthropic-ratelimit-requests-limit", "1000")
+	w.Header().Set("anthropic-ratelimit-requests-remaining", "999")
+	w.Header().Set("anthropic-ratelimit-requests-reset", "2022-01-01T00:00:00Z")
+	w.Header().Set("anthropic-ratelimit-tokens-limit", "1000")
+	w.Header().Set("anthropic-ratelimit-tokens-remaining", "999")
+	w.Header().Set("anthropic-ratelimit-tokens-reset", "2022-01-01T00:00:00Z")
+	w.Header().Set("retry-after", "0")
 
 	var dataBytes []byte
 

--- a/ratelimit_headers.go
+++ b/ratelimit_headers.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -26,20 +27,38 @@ type RateLimitHeaders struct {
 func newRateLimitHeaders(h http.Header) (RateLimitHeaders, error) {
 	errs := []error{}
 
+	// Requests
 	requestsLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-limit"))
-	errs = append(errs, err)
+	if err != nil {
+		err = fmt.Errorf("failed to parse anthropic-ratelimit-requests-limit: %w", err)
+		errs = append(errs, err)
+	}
 	requestsRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-requests-remaining"))
-	errs = append(errs, err)
+	if err != nil {
+		err = fmt.Errorf("failed to parse anthropic-ratelimit-requests-remaining: %w", err)
+		errs = append(errs, err)
+	}
 	requestsReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-requests-reset"))
-	errs = append(errs, err)
+	if err != nil {
+		err = fmt.Errorf("failed to parse anthropic-ratelimit-requests-reset: %w", err)
+		errs = append(errs, err)
+	}
 
+	// Tokens
 	tokensLimit, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-limit"))
-	errs = append(errs, err)
+	if err != nil {
+		err = fmt.Errorf("failed to parse anthropropic-ratelimit-tokens-limit: %w", err)
+		errs = append(errs, err)
+	}
 	tokensRemaining, err := strconv.Atoi(h.Get("anthropic-ratelimit-tokens-remaining"))
-	errs = append(errs, err)
+	if err != nil {
+		err = fmt.Errorf("failed to parse anthropropic-ratelimit-tokens-remaining: %w", err)
+		errs = append(errs, err)
+	}
 	tokensReset, err := time.Parse(time.RFC3339, h.Get("anthropic-ratelimit-tokens-reset"))
 	errs = append(errs, err)
 
+	// RetryAfter
 	retryAfter, err := strconv.Atoi(h.Get("retry-after"))
 	if err != nil {
 		retryAfter = -1


### PR DESCRIPTION
For chat completions with streaming, rate limit headers were getting destroyed by overwriting the response of the request with the first message of the stream starting.
This PR restores the headers, and adds them to the test.

Additionally, I put some work into making rate limit header parsing simpler, safer and clearer.