### PR TITLE
Integration test

### DIFF
--- a/integrationtest/complete_test.go
+++ b/integrationtest/complete_test.go
@@ -17,7 +17,7 @@ func TestIntegrationComplete(t *testing.T) {
 		request := anthropic.CompleteRequest{
 			Model:             anthropic.ModelClaudeInstant1Dot2,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
-			MaxTokensToSample: 1000,
+			MaxTokensToSample: 10,
 		}
 
 		resp, err := client.CreateComplete(ctx, request)

--- a/integrationtest/complete_test.go
+++ b/integrationtest/complete_test.go
@@ -1,0 +1,31 @@
+package integrationtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/liushuangls/go-anthropic/v2"
+)
+
+func TestIntegrationComplete(t *testing.T) {
+	testAPIKey(t)
+
+	t.Run("CreateComplete on real API", func(t *testing.T) {
+		client := anthropic.NewClient(APIKey)
+		ctx := context.Background()
+
+		request := anthropic.CompleteRequest{
+			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
+			MaxTokensToSample: 1000,
+		}
+
+		resp, err := client.CreateComplete(ctx, request)
+		if err != nil {
+			t.Fatalf("CreateComplete error: %s", err)
+		}
+		t.Logf("CreateComplete resp: %+v", resp)
+
+		// RateLimitHeaders are not present on the Completions endpoint
+	})
+}

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -1,0 +1,16 @@
+package integrationtest
+
+import (
+	"os"
+	"testing"
+)
+
+var (
+	APIKey = os.Getenv("ANTHROPIC_KEY")
+)
+
+func testAPIKey(t *testing.T) {
+	if APIKey == "" {
+		t.Fatal("ANTHROPIC_API_KEY must be set for integration tests")
+	}
+}

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -11,6 +11,6 @@ var (
 
 func testAPIKey(t *testing.T) {
 	if APIKey == "" {
-		t.Fatal("ANTHROPIC_API_KEY must be set for integration tests")
+		t.Fatal("ANTHROPIC_KEY must be set for integration tests")
 	}
 }

--- a/integrationtest/messages_test.go
+++ b/integrationtest/messages_test.go
@@ -1,0 +1,60 @@
+package integrationtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/liushuangls/go-anthropic/v2"
+)
+
+func TestIntegrationMessages(t *testing.T) {
+	testAPIKey(t)
+	client := anthropic.NewClient(APIKey)
+	ctx := context.Background()
+
+	request := anthropic.MessagesRequest{
+		Model:       anthropic.ModelClaude3Haiku20240307,
+		MultiSystem: anthropic.NewMultiSystemMessages("you are an assistant", "you are snarky"),
+		MaxTokens:   10,
+		Messages: []anthropic.Message{
+			anthropic.NewUserTextMessage("What is your name?"),
+			anthropic.NewAssistantTextMessage("My name is Claude."),
+			anthropic.NewUserTextMessage("What is your favorite color?"),
+		},
+	}
+
+	t.Run("CreateMessages on real API", func(t *testing.T) {
+		resp, err := client.CreateMessages(ctx, request)
+		if err != nil {
+			t.Fatalf("CreateMessages error: %s", err)
+		}
+		t.Logf("CreateMessages resp: %+v", resp)
+
+		t.Run("RateLimitHeaders are present", func(t *testing.T) {
+			rateLimHeader, err := resp.GetRateLimitHeaders()
+			if err != nil {
+				t.Fatalf("GetRateLimitHeaders error: %s", err)
+			}
+			t.Logf("RateLimitHeaders: %+v", rateLimHeader)
+		})
+	})
+
+	t.Run("CreateMessagesStream on real API", func(t *testing.T) {
+		streamRequest := anthropic.MessagesStreamRequest{
+			MessagesRequest: request,
+		}
+		resp, err := client.CreateMessagesStream(ctx, streamRequest)
+		if err != nil {
+			t.Fatalf("CreateMessagesStream error: %s", err)
+		}
+		t.Logf("CreateMessagesStream resp: %+v", resp)
+
+		t.Run("RateLimitHeaders are present", func(t *testing.T) {
+			rateLimHeader, err := resp.GetRateLimitHeaders()
+			if err != nil {
+				t.Fatalf("GetRateLimitHeaders error: %s", err)
+			}
+			t.Logf("RateLimitHeaders: %+v", rateLimHeader)
+		})
+	})
+}


### PR DESCRIPTION
This PR adds an integration test which is separate from the other tests in the repo.
To run the test, do `go test ./integrationtest`

The cost for doing so is pretty tiny (~ 1/100 of a cent). Although I can cut it down more.
For all cost calculations, out tokens is the maximum possible output from these tests.

| Model                                      | In | Out | Mode        | Cost            |
|-----------------------------------------|----|-------|----------------|-----------------|
| claude-3-haiku-20240307    | 39 | 10  | Streaming | $2.225E-5  |
| claude-3-haiku-20240307    | 39 | 10  | HTTP          | $2.225E-5  |
| claude-instant-1.2                 | 14 | 10  | HTTP          | $3.520E-5  |

Total Cost = $7.97E-5 / run
= $0.0000797 / run


The reason I've added these here is because I found I kept copy-pasting into my project folder an example I wrote to run tests, against the real API, when instead I'd rather just have a fully defined integration test to test against (that covers more testing points).