### PR TITLE
BetaVersion and APIVersion types with test

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,9 +79,17 @@ func (c *Client) fullURL(suffix string) string {
 
 type requestSetter func(req *http.Request)
 
-func withBetaVersion(version BetaVersion) requestSetter {
+func withBetaVersion(betaVersion ...BetaVersion) requestSetter {
+	version := ""
+	for i, v := range betaVersion {
+		version += string(v)
+		if i < len(betaVersion)-1 {
+			version += ","
+		}
+	}
+
 	return func(req *http.Request) {
-		req.Header.Set("anthropic-beta", string(version))
+		req.Header.Set("anthropic-beta", version)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -79,9 +79,9 @@ func (c *Client) fullURL(suffix string) string {
 
 type requestSetter func(req *http.Request)
 
-func withBetaVersion(version string) requestSetter {
+func withBetaVersion(version BetaVersion) requestSetter {
 	return func(req *http.Request) {
-		req.Header.Set("anthropic-beta", version)
+		req.Header.Set("anthropic-beta", string(version))
 	}
 }
 
@@ -102,7 +102,7 @@ func (c *Client) newRequest(ctx context.Context, method, urlSuffix string, body 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 	req.Header.Set("X-Api-Key", c.config.apiKey)
-	req.Header.Set("Anthropic-Version", c.config.APIVersion)
+	req.Header.Set("Anthropic-Version", string(c.config.APIVersion))
 
 	for _, setter := range requestSetters {
 		setter(req)

--- a/client_test.go
+++ b/client_test.go
@@ -6,14 +6,29 @@ import (
 )
 
 func TestWithBetaVersion(t *testing.T) {
-	opt := withBetaVersion("fake-version")
-	request, err := http.NewRequest("GET", "http://example.com", nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest error: %s", err)
-	}
-	opt(request)
+	t.Run("single beta version", func(t *testing.T) {
+		opt := withBetaVersion("fake-version")
+		request, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest error: %s", err)
+		}
+		opt(request)
 
-	if req := request.Header.Get("anthropic-beta"); req != "fake-version" {
-		t.Errorf("unexpected BetaVersion: %s", req)
-	}
+		if req := request.Header.Get("anthropic-beta"); req != "fake-version" {
+			t.Errorf("unexpected BetaVersion: %s", req)
+		}
+	})
+
+	t.Run("multiple beta versions", func(t *testing.T) {
+		opt := withBetaVersion("fake-version1", "fake-version2")
+		request, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("http.NewRequest error: %s", err)
+		}
+		opt(request)
+
+		if req := request.Header.Get("anthropic-beta"); req != "fake-version1,fake-version2" {
+			t.Errorf("unexpected BetaVersion: %s", req)
+		}
+	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,19 @@
+package anthropic
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestWithBetaVersion(t *testing.T) {
+	opt := withBetaVersion("fake-version")
+	request, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest error: %s", err)
+	}
+	opt(request)
+
+	if req := request.Header.Get("anthropic-beta"); req != "fake-version" {
+		t.Errorf("unexpected BetaVersion: %s", req)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ type ClientConfig struct {
 
 	BaseURL     string
 	APIVersion  APIVersion
-	BetaVersion BetaVersion
+	BetaVersion []BetaVersion
 	HTTPClient  *http.Client
 
 	EmptyMessagesLimit uint
@@ -82,15 +82,7 @@ func WithEmptyMessagesLimit(limit uint) ClientOption {
 }
 
 func WithBetaVersion(betaVersion ...BetaVersion) ClientOption {
-	version := ""
-	for i, v := range betaVersion {
-		version += string(v)
-		if i < len(betaVersion)-1 {
-			version += ","
-		}
-	}
-
 	return func(c *ClientConfig) {
-		c.BetaVersion = BetaVersion(version)
+		c.BetaVersion = betaVersion
 	}
 }

--- a/config.go
+++ b/config.go
@@ -81,8 +81,16 @@ func WithEmptyMessagesLimit(limit uint) ClientOption {
 	}
 }
 
-func WithBetaVersion(betaVersion BetaVersion) ClientOption {
+func WithBetaVersion(betaVersion ...BetaVersion) ClientOption {
+	version := ""
+	for i, v := range betaVersion {
+		version += string(v)
+		if i < len(betaVersion)-1 {
+			version += ","
+		}
+	}
+
 	return func(c *ClientConfig) {
-		c.BetaVersion = betaVersion
+		c.BetaVersion = BetaVersion(version)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -9,16 +9,20 @@ const (
 	defaultEmptyMessagesLimit uint = 300
 )
 
+type APIVersion string
+
 const (
-	APIVersion20230601 = "2023-06-01"
+	APIVersion20230601 APIVersion = "2023-06-01"
 )
 
-const (
-	BetaTools20240404         = "tools-2024-04-04"
-	BetaTools20240516         = "tools-2024-05-16"
-	BetaPromptCaching20240731 = "prompt-caching-2024-07-31"
+type BetaVersion string
 
-	BetaMaxTokens35Sonnet20240715 = "max-tokens-3-5-sonnet-2024-07-15"
+const (
+	BetaTools20240404         BetaVersion = "tools-2024-04-04"
+	BetaTools20240516         BetaVersion = "tools-2024-05-16"
+	BetaPromptCaching20240731 BetaVersion = "prompt-caching-2024-07-31"
+
+	BetaMaxTokens35Sonnet20240715 BetaVersion = "max-tokens-3-5-sonnet-2024-07-15"
 )
 
 // ClientConfig is a configuration of a client.
@@ -26,8 +30,8 @@ type ClientConfig struct {
 	apiKey string
 
 	BaseURL     string
-	APIVersion  string
-	BetaVersion string
+	APIVersion  APIVersion
+	BetaVersion BetaVersion
 	HTTPClient  *http.Client
 
 	EmptyMessagesLimit uint
@@ -59,7 +63,7 @@ func WithBaseURL(baseUrl string) ClientOption {
 	}
 }
 
-func WithAPIVersion(apiVersion string) ClientOption {
+func WithAPIVersion(apiVersion APIVersion) ClientOption {
 	return func(c *ClientConfig) {
 		c.APIVersion = apiVersion
 	}
@@ -77,7 +81,7 @@ func WithEmptyMessagesLimit(limit uint) ClientOption {
 	}
 }
 
-func WithBetaVersion(betaVersion string) ClientOption {
+func WithBetaVersion(betaVersion BetaVersion) ClientOption {
 	return func(c *ClientConfig) {
 		c.BetaVersion = betaVersion
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,83 @@
+package anthropic_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/liushuangls/go-anthropic/v2"
+)
+
+func TestWithBaseURL(t *testing.T) {
+	fakeBaseURL := "fake-url!"
+	opt := anthropic.WithBaseURL(fakeBaseURL)
+
+	c := anthropic.ClientConfig{}
+	opt(&c)
+
+	if c.BaseURL != fakeBaseURL {
+		t.Errorf("unexpected BaseURL: %s", c.BaseURL)
+	}
+}
+
+func TestWithAPIVersion(t *testing.T) {
+	t.Run("single generic version", func(t *testing.T) {
+		fakeAPIVersion := anthropic.APIVersion("fake-version")
+		opt := anthropic.WithAPIVersion(fakeAPIVersion)
+
+		c := anthropic.ClientConfig{}
+		opt(&c)
+
+		if c.APIVersion != fakeAPIVersion {
+			t.Errorf("unexpected APIVersion: %s", c.APIVersion)
+		}
+	})
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	fakeHTTPClient := http.Client{}
+	fakeHTTPClient.Timeout = 1234
+
+	opt := anthropic.WithHTTPClient(&fakeHTTPClient)
+
+	c := anthropic.ClientConfig{}
+	opt(&c)
+
+	if c.HTTPClient != &fakeHTTPClient {
+		t.Errorf("unexpected HTTPClient: %v", c.HTTPClient)
+	}
+}
+
+func TestWithEmptyMessagesLimit(t *testing.T) {
+	fakeLimit := uint(1234)
+	opt := anthropic.WithEmptyMessagesLimit(fakeLimit)
+
+	c := anthropic.ClientConfig{}
+	opt(&c)
+
+	if c.EmptyMessagesLimit != fakeLimit {
+		t.Errorf("unexpected EmptyMessagesLimit: %d", c.EmptyMessagesLimit)
+	}
+}
+
+func TestWithBetaVersion(t *testing.T) {
+	t.Run("single generic version", func(t *testing.T) {
+		fakeBetaVersion := anthropic.BetaVersion("fake-version")
+		opt := anthropic.WithBetaVersion(fakeBetaVersion)
+		c := anthropic.ClientConfig{}
+		opt(&c)
+
+		if c.BetaVersion != fakeBetaVersion {
+			t.Errorf("unexpected BetaVersion: %s", c.BetaVersion)
+		}
+	})
+
+	t.Run("multiple versions", func(t *testing.T) {
+		opt := anthropic.WithBetaVersion("foo", "bar")
+		c := anthropic.ClientConfig{}
+		opt(&c)
+
+		if c.BetaVersion != "foo,bar" {
+			t.Errorf("unexpected BetaVersion: %s", c.BetaVersion)
+		}
+	})
+}

--- a/config_test.go
+++ b/config_test.go
@@ -66,8 +66,11 @@ func TestWithBetaVersion(t *testing.T) {
 		c := anthropic.ClientConfig{}
 		opt(&c)
 
-		if c.BetaVersion != fakeBetaVersion {
+		if c.BetaVersion[0] != fakeBetaVersion {
 			t.Errorf("unexpected BetaVersion: %s", c.BetaVersion)
+		}
+		if len(c.BetaVersion) != 1 {
+			t.Errorf("unexpected BetaVersion length: %d", len(c.BetaVersion))
 		}
 	})
 
@@ -76,8 +79,8 @@ func TestWithBetaVersion(t *testing.T) {
 		c := anthropic.ClientConfig{}
 		opt(&c)
 
-		if c.BetaVersion != "foo,bar" {
-			t.Errorf("unexpected BetaVersion: %s", c.BetaVersion)
+		if len(c.BetaVersion) != 2 {
+			t.Errorf("unexpected BetaVersion length: %d", len(c.BetaVersion))
 		}
 	})
 }

--- a/integrationtest/messages_test.go
+++ b/integrationtest/messages_test.go
@@ -24,7 +24,10 @@ func TestIntegrationMessages(t *testing.T) {
 	}
 
 	t.Run("CreateMessages on real API", func(t *testing.T) {
-		resp, err := client.CreateMessages(ctx, request)
+		betaOpts := anthropic.WithBetaVersion(anthropic.BetaTools20240404, anthropic.BetaMaxTokens35Sonnet20240715)
+		newClient := anthropic.NewClient(APIKey, betaOpts)
+
+		resp, err := newClient.CreateMessages(ctx, request)
 		if err != nil {
 			t.Fatalf("CreateMessages error: %s", err)
 		}

--- a/message.go
+++ b/message.go
@@ -317,7 +317,7 @@ type MessagesUsage struct {
 	// The number of tokens written to the cache when creating a new entry.
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	// The number of tokens retrieved from the cache for associated request.
-	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+	CacheReadInputTokens int `json:"cache_read_input_tokens,omitempty"`
 }
 
 type ToolDefinition struct {
@@ -342,7 +342,7 @@ func (c *Client) CreateMessages(ctx context.Context, request MessagesRequest) (r
 
 	var setters []requestSetter
 	if len(c.config.BetaVersion) > 0 {
-		setters = append(setters, withBetaVersion(c.config.BetaVersion))
+		setters = append(setters, withBetaVersion(c.config.BetaVersion...))
 	}
 
 	urlSuffix := "/messages"

--- a/message_stream.go
+++ b/message_stream.go
@@ -87,7 +87,7 @@ func (c *Client) CreateMessagesStream(ctx context.Context, request MessagesStrea
 
 	var setters []requestSetter
 	if len(c.config.BetaVersion) > 0 {
-		setters = append(setters, withBetaVersion(c.config.BetaVersion))
+		setters = append(setters, withBetaVersion(c.config.BetaVersion...))
 	}
 
 	urlSuffix := "/messages"

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -111,54 +111,6 @@ func TestMessagesStreamError(t *testing.T) {
 }
 
 func TestCreateMessagesStream(t *testing.T) {
-	t.Run("Accepts generic beta version", func(t *testing.T) {
-		server := test.NewTestServer()
-		server.RegisterHandler("/v1/messages", handlerMessagesStreamToolUse)
-
-		ts := server.AnthropicTestServer()
-		ts.Start()
-		defer ts.Close()
-		baseUrl := ts.URL + "/v1"
-
-		client := anthropic.NewClient(test.GetTestToken(), anthropic.WithBaseURL(baseUrl), anthropic.WithBetaVersion("beta-version"))
-		_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
-			MessagesRequest: anthropic.MessagesRequest{
-				Model: anthropic.ModelClaudeInstant1Dot2,
-				Messages: []anthropic.Message{
-					anthropic.NewUserTextMessage("What is your name?"),
-				},
-				MaxTokens: 1000,
-			},
-		})
-		if err != nil {
-			t.Fatalf("CreateMessagesStream error: %s", err)
-		}
-	})
-
-	t.Run("Accepts generic API version", func(t *testing.T) {
-		server := test.NewTestServer()
-		server.RegisterHandler("/v1/messages", handlerMessagesStreamToolUse)
-
-		ts := server.AnthropicTestServer()
-		ts.Start()
-		defer ts.Close()
-		baseUrl := ts.URL + "/v1"
-
-		client := anthropic.NewClient(test.GetTestToken(), anthropic.WithBaseURL(baseUrl), anthropic.WithAPIVersion("api-version"))
-		_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
-			MessagesRequest: anthropic.MessagesRequest{
-				Model: anthropic.ModelClaudeInstant1Dot2,
-				Messages: []anthropic.Message{
-					anthropic.NewUserTextMessage("What is your name?"),
-				},
-				MaxTokens: 1000,
-			},
-		})
-		if err != nil {
-			t.Fatalf("CreateMessagesStream error: %s", err)
-		}
-	})
-
 	t.Run("Does not error for empty unknown messages below limit", func(t *testing.T) {
 		emptyMessagesLimit := 100
 		server := test.NewTestServer()

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -135,6 +135,30 @@ func TestCreateMessagesStream(t *testing.T) {
 		}
 	})
 
+	t.Run("Accepts generic API version", func(t *testing.T) {
+		server := test.NewTestServer()
+		server.RegisterHandler("/v1/messages", handlerMessagesStreamToolUse)
+
+		ts := server.AnthropicTestServer()
+		ts.Start()
+		defer ts.Close()
+		baseUrl := ts.URL + "/v1"
+
+		client := anthropic.NewClient(test.GetTestToken(), anthropic.WithBaseURL(baseUrl), anthropic.WithAPIVersion("api-version"))
+		_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
+			MessagesRequest: anthropic.MessagesRequest{
+				Model: anthropic.ModelClaudeInstant1Dot2,
+				Messages: []anthropic.Message{
+					anthropic.NewUserTextMessage("What is your name?"),
+				},
+				MaxTokens: 1000,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateMessagesStream error: %s", err)
+		}
+	})
+
 	t.Run("Does not error for empty unknown messages below limit", func(t *testing.T) {
 		emptyMessagesLimit := 100
 		server := test.NewTestServer()


### PR DESCRIPTION
Similarly to #14 where `ChatRole` and `Model` types were added, this PR adds types for `APIVersion` and `BetaVersion`.

We no longer need "Accepts generic beta version" on stream tests as config_test.go covers all cases there.
Tests have been added for config.go exported functions, and `withBetaVersion` within client.go