### PR TITLE
Claude 1 Deprecation Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import (
 func main() {
 	client := anthropic.NewClient("your anthropic api key")
 	resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-		Model: anthropic.ModelClaudeInstant1Dot2,
+		Model: anthropic.ModelClaude3Haiku20240307,
 		Messages: []anthropic.Message{
 			anthropic.NewUserTextMessage("What is your name?"),
 		},
@@ -75,7 +75,7 @@ func main() {
 	client := anthropic.NewClient("your anthropic api key")
 	resp, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
 		MessagesRequest: anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},

--- a/common.go
+++ b/common.go
@@ -3,7 +3,6 @@ package anthropic
 type Model string
 
 const (
-	ModelClaudeInstant1Dot2        Model = "claude-instant-1.2"
 	ModelClaude2Dot0               Model = "claude-2.0"
 	ModelClaude2Dot1               Model = "claude-2.1"
 	ModelClaude3Opus20240229       Model = "claude-3-opus-20240229"

--- a/complete_stream_test.go
+++ b/complete_stream_test.go
@@ -33,7 +33,7 @@ func TestCompleteStream(t *testing.T) {
 	var receivedContent string
 	resp, err := client.CreateCompleteStream(context.Background(), anthropic.CompleteStreamRequest{
 		CompleteRequest: anthropic.CompleteRequest{
-			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Model:             anthropic.ModelClaude3Haiku20240307,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 			MaxTokensToSample: 1000,
 		},
@@ -82,7 +82,7 @@ func TestCompleteStreamError(t *testing.T) {
 	var receivedContent string
 	param := anthropic.CompleteStreamRequest{
 		CompleteRequest: anthropic.CompleteRequest{
-			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Model:             anthropic.ModelClaude3Haiku20240307,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 			MaxTokensToSample: 1000,
 			//Temperature:       &temperature,
@@ -135,7 +135,7 @@ func handlerCompleteStream(w http.ResponseWriter, r *http.Request) {
 			dataBytes,
 			[]byte(
 				fmt.Sprintf(
-					`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"%s","stop_reason":null,"model":"claude-instant-1.2","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`,
+					`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"%s","stop_reason":null,"model":"claude-3-haiku-20240307"","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`,
 					t,
 				)+"\n\n",
 			)...)
@@ -145,7 +145,7 @@ func handlerCompleteStream(w http.ResponseWriter, r *http.Request) {
 	dataBytes = append(
 		dataBytes,
 		[]byte(
-			`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"","stop_reason":"stop_sequence","model":"claude-instant-1.2","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`+"\n\n",
+			`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"","stop_reason":"stop_sequence","model":"claude-3-haiku-20240307"","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`+"\n\n",
 		)...)
 
 	_, _ = w.Write(dataBytes)

--- a/complete_stream_test.go
+++ b/complete_stream_test.go
@@ -135,7 +135,7 @@ func handlerCompleteStream(w http.ResponseWriter, r *http.Request) {
 			dataBytes,
 			[]byte(
 				fmt.Sprintf(
-					`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"%s","stop_reason":null,"model":"claude-3-haiku-20240307"","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`,
+					`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"%s","stop_reason":null,"model":"claude-3-haiku-20240307","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`,
 					t,
 				)+"\n\n",
 			)...)
@@ -145,7 +145,7 @@ func handlerCompleteStream(w http.ResponseWriter, r *http.Request) {
 	dataBytes = append(
 		dataBytes,
 		[]byte(
-			`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"","stop_reason":"stop_sequence","model":"claude-3-haiku-20240307"","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`+"\n\n",
+			`data: {"type":"completion","id":"compl_01GatBXF5t5K51mYzbVgRJfZ","completion":"","stop_reason":"stop_sequence","model":"claude-3-haiku-20240307","stop":null,"log_id":"compl_01GatBXF5t5K51mYzbVgRJfZ"}`+"\n\n",
 		)...)
 
 	_, _ = w.Write(dataBytes)

--- a/complete_test.go
+++ b/complete_test.go
@@ -26,7 +26,7 @@ func TestComplete(t *testing.T) {
 	t.Run("create complete success", func(t *testing.T) {
 		client := anthropic.NewClient(test.GetTestToken(), anthropic.WithBaseURL(baseUrl))
 		resp, err := client.CreateComplete(context.Background(), anthropic.CompleteRequest{
-			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Model:             anthropic.ModelClaude3Haiku20240307,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 			MaxTokensToSample: 1000,
 		})
@@ -40,7 +40,7 @@ func TestComplete(t *testing.T) {
 	t.Run("create complete failure", func(t *testing.T) {
 		client := anthropic.NewClient("invalid token", anthropic.WithBaseURL(baseUrl))
 		_, err := client.CreateComplete(context.Background(), anthropic.CompleteRequest{
-			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Model:             anthropic.ModelClaude3Haiku20240307,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 			MaxTokensToSample: 1000,
 		})
@@ -52,7 +52,7 @@ func TestComplete(t *testing.T) {
 
 func TestSetTemperature(t *testing.T) {
 	cr := anthropic.CompleteRequest{
-		Model:             anthropic.ModelClaudeInstant1Dot2,
+		Model:             anthropic.ModelClaude3Haiku20240307,
 		Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 		MaxTokensToSample: 1000,
 	}
@@ -67,7 +67,7 @@ func TestSetTemperature(t *testing.T) {
 
 func TestSetTopP(t *testing.T) {
 	cr := anthropic.CompleteRequest{
-		Model:             anthropic.ModelClaudeInstant1Dot2,
+		Model:             anthropic.ModelClaude3Haiku20240307,
 		Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 		MaxTokensToSample: 1000,
 	}
@@ -82,7 +82,7 @@ func TestSetTopP(t *testing.T) {
 
 func TestSetTopK(t *testing.T) {
 	cr := anthropic.CompleteRequest{
-		Model:             anthropic.ModelClaudeInstant1Dot2,
+		Model:             anthropic.ModelClaude3Haiku20240307,
 		Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 		MaxTokensToSample: 1000,
 	}

--- a/integrationtest/complete_test.go
+++ b/integrationtest/complete_test.go
@@ -15,7 +15,7 @@ func TestIntegrationComplete(t *testing.T) {
 		ctx := context.Background()
 
 		request := anthropic.CompleteRequest{
-			Model:             anthropic.ModelClaudeInstant1Dot2,
+			Model:             anthropic.ModelClaude2Dot1,
 			Prompt:            "\n\nHuman: What is your name?\n\nAssistant:",
 			MaxTokensToSample: 10,
 		}

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -34,7 +34,7 @@ func TestMessagesStream(t *testing.T) {
 	var received string
 	resp, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
 		MessagesRequest: anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -96,7 +96,7 @@ func TestMessagesStreamError(t *testing.T) {
 	)
 	param := anthropic.MessagesStreamRequest{
 		MessagesRequest: anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -138,7 +138,7 @@ func TestCreateMessagesStream(t *testing.T) {
 		)
 		_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
 			MessagesRequest: anthropic.MessagesRequest{
-				Model:     anthropic.ModelClaudeInstant1Dot2,
+				Model:     anthropic.ModelClaude3Haiku20240307,
 				Messages:  []anthropic.Message{},
 				MaxTokens: 1000,
 			},
@@ -168,7 +168,7 @@ func TestCreateMessagesStream(t *testing.T) {
 		)
 		_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
 			MessagesRequest: anthropic.MessagesRequest{
-				Model: anthropic.ModelClaudeInstant1Dot2,
+				Model: anthropic.ModelClaude3Haiku20240307,
 				Messages: []anthropic.Message{
 					anthropic.NewUserTextMessage("What's the weather like?"),
 				},
@@ -320,7 +320,7 @@ func handlerMessagesStream(w http.ResponseWriter, r *http.Request) {
 	dataBytes = append(
 		dataBytes,
 		[]byte(
-			`data: {"type":"message_start","message":{"id":"1","type":"message","role":"assistant","content":[],"model":"claude-instant-1.2","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"output_tokens":1}}}`+"\n\n",
+			`data: {"type":"message_start","message":{"id":"1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"output_tokens":1}}}`+"\n\n",
 		)...)
 
 	dataBytes = append(dataBytes, []byte("event: content_block_start\n")...)

--- a/message_test.go
+++ b/message_test.go
@@ -50,7 +50,7 @@ func TestMessages(t *testing.T) {
 
 	t.Run("create messages success", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -65,7 +65,7 @@ func TestMessages(t *testing.T) {
 
 	t.Run("create messages success with single system message", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -81,7 +81,7 @@ func TestMessages(t *testing.T) {
 
 	t.Run("create messages success with single multi-system message", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -97,7 +97,7 @@ func TestMessages(t *testing.T) {
 
 	t.Run("create messages success with multi-system messages", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				anthropic.NewUserTextMessage("What is your name?"),
 			},
@@ -281,7 +281,7 @@ func TestMessagesTokenError(t *testing.T) {
 		anthropic.WithBaseURL(baseUrl),
 	)
 	_, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-		Model: anthropic.ModelClaudeInstant1Dot2,
+		Model: anthropic.ModelClaude3Haiku20240307,
 		Messages: []anthropic.Message{
 			anthropic.NewUserTextMessage("What is your name?"),
 		},
@@ -562,7 +562,7 @@ func TestMessagesWithCaching(t *testing.T) {
 
 	t.Run("caches single message", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			Messages: []anthropic.Message{
 				{
 					Role: anthropic.RoleUser,
@@ -588,7 +588,7 @@ func TestMessagesWithCaching(t *testing.T) {
 
 	t.Run("caches a multi-system message", func(t *testing.T) {
 		resp, err := client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-			Model: anthropic.ModelClaudeInstant1Dot2,
+			Model: anthropic.ModelClaude3Haiku20240307,
 			MultiSystem: []anthropic.MessageSystemPart{
 				{
 					Type: "text",


### PR DESCRIPTION
https://docs.anthropic.com/en/docs/resources/model-deprecations
Claude 1 models are deprecated as of September 4, 2024 and will be retired on November 6, 2024.

Closes #24 


This PR removes all references to Claude 1 models, and updates the model in tests where appropriate.