### PR TITLE
feat: add claude-3-5-sonnet-20241022 model

### DIFF
--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ const (
 	ModelClaude3Opus20240229       Model = "claude-3-opus-20240229"
 	ModelClaude3Sonnet20240229     Model = "claude-3-sonnet-20240229"
 	ModelClaude3Dot5Sonnet20240620 Model = "claude-3-5-sonnet-20240620"
+	ModelClaude3Dot5Sonnet20241022 Model = "claude-3-5-sonnet-20241022"
 	ModelClaude3Haiku20240307      Model = "claude-3-haiku-20240307"
 )
 

--- a/common.go
+++ b/common.go
@@ -10,6 +10,7 @@ const (
 	ModelClaude3Sonnet20240229     Model = "claude-3-sonnet-20240229"
 	ModelClaude3Dot5Sonnet20240620 Model = "claude-3-5-sonnet-20240620"
 	ModelClaude3Dot5Sonnet20241022 Model = "claude-3-5-sonnet-20241022"
+	ModelClaude3Dot5SonnetLatest   Model = "claude-3-5-sonnet-latest"
 	ModelClaude3Haiku20240307      Model = "claude-3-haiku-20240307"
 )
 


### PR DESCRIPTION
Hi, thanks for the great package.

Today a new version of Claude 3.5 Sonnet got introduced, I added it to the model constants and tested it successfully.

As per [model table](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison-table), the older version is still available for use via API. 

Also, as seen [here](https://docs.anthropic.com/en/docs/about-claude/models#model-names), `claude-3-5-sonnet-latest` can be used as a shortcut for the latest version of Sonnet.