### PR TITLE
bugfix: Fix VertexAI model name for Claude 3.5 Sonnet 20241022 release

### DIFF
--- a/common.go
+++ b/common.go
@@ -31,7 +31,7 @@ func (m Model) asVertexModel() string {
 	case ModelClaude3Dot5Sonnet20240620:
 		return "claude-3-5-sonnet@20240620"
 	case ModelClaude3Dot5Sonnet20241022:
-		return "claude-3-5-sonnet@20241022"
+		return "claude-3-5-sonnet-v2@20241022"
 	case ModelClaude3Haiku20240307:
 		return "claude-3-haiku@20240307"
 	case ModelClaude3Dot5Haiku20241022:


### PR DESCRIPTION
VertexAI adds a `-v2` extension to the model name for the Claude 3.5 Sonnet 20241022 release.

See: https://console.cloud.google.com/vertex-ai/publishers/anthropic/model-garden/claude-3-5-sonnet-v2

Attempting to run without the `-v2` extension yields the following error:
```
error, status code: 404, message: vertex api error code: 404, status: NOT_FOUND, message: Publisher Model `projects/minisme-env-mmann/locations/us-east5/publishers/anthropic/models/claude-3-5-sonnet@20241022` not found.
```