### PR TITLE
Transform HTTP 403 (Forbidden) error returned by VertexAI API

### DIFF
--- a/vertexadapter.go
+++ b/vertexadapter.go
@@ -12,7 +12,11 @@ type VertexAdapter struct {
 }
 
 func (v *VertexAdapter) TranslateError(resp *http.Response, body []byte) (error, bool) {
-	if resp.StatusCode == 401 || resp.StatusCode == 404 || resp.StatusCode == 429 {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusTooManyRequests:
 		var errRes VertexAIErrorResponse
 		err := json.Unmarshal(body, &errRes)
 		if err != nil {
@@ -38,7 +42,6 @@ func (v *VertexAdapter) TranslateError(resp *http.Response, body []byte) (error,
 			errRes.Error,
 		), true
 	}
-
 	return nil, false
 }
 


### PR DESCRIPTION
The `VertexAdapater.TransformError` method was not handling HTTP 403 errors, resulting in a failed unmarshal into a standard anthropic `ResponseError`.