### PR TITLE
Translate BadRequest errors.

### DIFF
--- a/vertexadapter.go
+++ b/vertexadapter.go
@@ -13,7 +13,8 @@ type VertexAdapter struct {
 
 func (v *VertexAdapter) TranslateError(resp *http.Response, body []byte) (error, bool) {
 	switch resp.StatusCode {
-	case http.StatusUnauthorized,
+	case http.StatusBadRequest,
+		http.StatusUnauthorized,
 		http.StatusForbidden,
 		http.StatusNotFound,
 		http.StatusTooManyRequests:


### PR DESCRIPTION
Here is a small change to also capture and translate 400 Bad Request errors.  An example of the error which will be translated is below:

```
{
  "error": {
    "code": 400,
    "message": "Project `XXX` is not allowed to use Publisher Model `projects/XXX/locations/us-central1/publishers/anthropic/models/claude-3-5-sonnet-v2@20241022`",
    "status": "FAILED_PRECONDITION"
  }
}
```