### PR TITLE
Add Claude Fable 5 to the model enum.

### DIFF
--- a/common.go
+++ b/common.go
@@ -31,6 +31,7 @@ const (
 	ModelClaudeOpus4Dot6            Model = "claude-opus-4-6"
 	ModelClaudeOpus4Dot7            Model = "claude-opus-4-7"
 	ModelClaudeOpus4Dot8            Model = "claude-opus-4-8"
+	ModelClaudeFable5               Model = "claude-fable-5"
 )
 
 type ChatRole string
@@ -74,6 +75,10 @@ func (m Model) asVertexModel() string {
 		return "claude-opus-4-6"
 	case ModelClaudeOpus4Dot7:
 		return "claude-opus-4-7"
+	case ModelClaudeOpus4Dot8:
+		return "claude-opus-4-8"
+	case ModelClaudeFable5:
+		return "claude-fable-5"
 	default:
 		return string(m)
 	}


### PR DESCRIPTION
This PR adds Claude Fable 5 to the models enum and asVertexModel.

It also fixes a harmless mistake by omission in my last PR to update the `asVertexModel` method to properly handle the Claude Opus 4.8 model enum value.