### PR TITLE
Enable Automatic Prompt Caching Parameter

### DIFF
--- a/message.go
+++ b/message.go
@@ -102,8 +102,9 @@ type MessagesRequest struct {
 	ToolChoice    *ToolChoice         `json:"tool_choice,omitempty"`
 	Thinking      *Thinking           `json:"thinking,omitempty"`
 	// Deprecated: Use output_config.format instead.
-	OutputFormat *OutputFormat `json:"output_format,omitempty"`
-	OutputConfig *OutputConfig `json:"output_config,omitempty"`
+	OutputFormat *OutputFormat        `json:"output_format,omitempty"`
+	OutputConfig *OutputConfig        `json:"output_config,omitempty"`
+	CacheControl *MessageCacheControl `json:"cache_control,omitempty"`
 }
 
 func (m MessagesRequest) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
This PR makes a small change to add a `CacheControl` parameter to the `MessagesRequest` type, with a corresponding JSON tag so that it can be sent as part of the request. By adding this, users can add a `MessageCacheControl` object to the top-level request, which allows them to enable [automatic caching].

I have ensured to look closely at the Anthropic Stainless SDK for the expected JSON tags and object shapes to make sure this is consistent with their API.

In addition, I have tested this and confirmed that no HTTP 400 error is returned by the Anthropic API when setting top-level cache control.

[automatic caching]: https://platform.claude.com/docs/en/build-with-claude/prompt-caching