### PR TITLE
Add Support For Web Search Tool

### DIFF
--- a/message.go
+++ b/message.go
@@ -16,26 +16,29 @@ const (
 type MessagesContentType string
 
 const (
-	MessagesContentTypeText             MessagesContentType = "text"
-	MessagesContentTypeTextDelta        MessagesContentType = "text_delta"
-	MessagesContentTypeImage            MessagesContentType = "image"
-	MessagesContentTypeToolResult       MessagesContentType = "tool_result"
-	MessagesContentTypeToolUse          MessagesContentType = "tool_use"
-	MessagesContentTypeInputJsonDelta   MessagesContentType = "input_json_delta"
-	MessagesContentTypeDocument         MessagesContentType = "document"
-	MessagesContentTypeCitationsDelta   MessagesContentType = "citations_delta"
-	MessagesContentTypeThinking         MessagesContentType = "thinking"
-	MessagesContentTypeThinkingDelta    MessagesContentType = "thinking_delta"
-	MessagesContentTypeSignatureDelta   MessagesContentType = "signature_delta"
-	MessagesContentTypeRedactedThinking MessagesContentType = "redacted_thinking"
+	MessagesContentTypeText                MessagesContentType = "text"
+	MessagesContentTypeTextDelta           MessagesContentType = "text_delta"
+	MessagesContentTypeImage               MessagesContentType = "image"
+	MessagesContentTypeToolResult          MessagesContentType = "tool_result"
+	MessagesContentTypeToolUse             MessagesContentType = "tool_use"
+	MessagesContentTypeInputJsonDelta      MessagesContentType = "input_json_delta"
+	MessagesContentTypeDocument            MessagesContentType = "document"
+	MessagesContentTypeCitationsDelta      MessagesContentType = "citations_delta"
+	MessagesContentTypeThinking            MessagesContentType = "thinking"
+	MessagesContentTypeThinkingDelta       MessagesContentType = "thinking_delta"
+	MessagesContentTypeSignatureDelta      MessagesContentType = "signature_delta"
+	MessagesContentTypeRedactedThinking    MessagesContentType = "redacted_thinking"
+	MessagesContentTypeServerToolUse       MessagesContentType = "server_tool_use"
+	MessagesContentTypeWebSearchToolResult MessagesContentType = "web_search_tool_result"
 )
 
 type CitationType string
 
 const (
-	CitationTypeCharLocation CitationType = "char_location"
-	CitationTypePageNumber   CitationType = "page_number"
-	CitationTypeBlockIndex   CitationType = "block_index"
+	CitationTypeCharLocation            CitationType = "char_location"
+	CitationTypePageNumber              CitationType = "page_number"
+	CitationTypeBlockIndex              CitationType = "block_index"
+	CitationTypeWebSearchResultLocation CitationType = "web_search_result_location"
 )
 
 type ThinkingType string
@@ -53,6 +56,7 @@ const (
 	MessagesStopReasonMaxTokens    MessagesStopReason = "max_tokens"
 	MessagesStopReasonStopSequence MessagesStopReason = "stop_sequence"
 	MessagesStopReasonToolUse      MessagesStopReason = "tool_use"
+	MessagesStopReasonPauseTurn    MessagesStopReason = "pause_turn"
 	MessagesStopRefusal            MessagesStopReason = "refusal"
 )
 
@@ -241,6 +245,11 @@ type Citation struct {
 	// For block_index citations
 	StartBlockIndex *int `json:"start_block_index,omitempty"`
 	EndBlockIndex   *int `json:"end_block_index,omitempty"`
+
+	// For web_search_result_location citations
+	EncryptedIndex *string `json:"encrypted_index,omitempty"`
+	Url            *string `json:"url,omitempty"`
+	Title          *string `json:"title,omitempty"`
 }
 
 type MessageContent struct {
@@ -253,6 +262,10 @@ type MessageContent struct {
 	*MessageContentToolResult
 
 	*MessageContentToolUse
+
+	*MessageContentWebSearchToolResult
+
+	*MessageContentServerToolUse
 
 	PartialJson *string `json:"partial_json,omitempty"`
 
@@ -279,6 +292,16 @@ type MessageContent struct {
 
 // UnmarshalJSON implements custom JSON unmarshaling for MessageContent
 func (m *MessageContent) UnmarshalJSON(data []byte) error {
+	// First, unmarshal to get the type field
+	type TypeOnly struct {
+		Type MessagesContentType `json:"type"`
+	}
+	var typeCheck TypeOnly
+	if err := json.Unmarshal(data, &typeCheck); err != nil {
+		return err
+	}
+
+	// Create an alias to avoid infinite recursion
 	type Alias MessageContent
 	aux := &struct {
 		Citations []Citation `json:"citations"`
@@ -286,12 +309,61 @@ func (m *MessageContent) UnmarshalJSON(data []byte) error {
 	}{
 		Alias: (*Alias)(m),
 	}
+
+	// Unmarshal into the alias
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
-	// Copy Citations from aux to m
+	// Copy citations
 	m.Citations = aux.Citations
+
+	// Based on type, create and populate the appropriate embedded struct
+	switch typeCheck.Type {
+	case MessagesContentTypeToolUse:
+		var toolUse MessageContentToolUse
+		if err := json.Unmarshal(data, &toolUse); err != nil {
+			return err
+		}
+		m.MessageContentToolUse = &toolUse
+
+	case MessagesContentTypeServerToolUse:
+		var serverToolUse MessageContentServerToolUse
+		if err := json.Unmarshal(data, &serverToolUse); err != nil {
+			return err
+		}
+		m.MessageContentServerToolUse = &serverToolUse
+
+	case MessagesContentTypeToolResult:
+		var toolResult MessageContentToolResult
+		if err := json.Unmarshal(data, &toolResult); err != nil {
+			return err
+		}
+		m.MessageContentToolResult = &toolResult
+
+	case MessagesContentTypeWebSearchToolResult:
+		var webSearchResult MessageContentWebSearchToolResult
+		if err := json.Unmarshal(data, &webSearchResult); err != nil {
+			return err
+		}
+		m.MessageContentWebSearchToolResult = &webSearchResult
+
+	case MessagesContentTypeThinking,
+		MessagesContentTypeThinkingDelta,
+		MessagesContentTypeSignatureDelta:
+		var thinking MessageContentThinking
+		if err := json.Unmarshal(data, &thinking); err != nil {
+			return err
+		}
+		m.MessageContentThinking = &thinking
+
+	case MessagesContentTypeRedactedThinking:
+		var redacted MessageContentRedactedThinking
+		if err := json.Unmarshal(data, &redacted); err != nil {
+			return err
+		}
+		m.MessageContentRedactedThinking = &redacted
+	}
 
 	return nil
 }
@@ -399,6 +471,26 @@ func NewToolUseMessageContent(toolUseID, name string, input json.RawMessage) Mes
 	}
 }
 
+func NewServerToolUseContent(toolUseID, name string, input json.RawMessage) MessageContent {
+	return MessageContent{
+		Type:                        MessagesContentTypeServerToolUse,
+		MessageContentServerToolUse: NewMessageContentServerToolUse(toolUseID, name, input),
+	}
+}
+
+func NewServerWebSearchToolResultContent(
+	toolUseID string,
+	content []WebSearchResult,
+) MessageContent {
+	return MessageContent{
+		Type: MessagesContentTypeWebSearchToolResult,
+		MessageContentWebSearchToolResult: NewMessageContentWebSearchToolResult(
+			toolUseID,
+			content,
+		),
+	}
+}
+
 func (m *MessageContent) SetCacheControl(ts ...CacheControlType) {
 	t := CacheControlTypeEphemeral
 	if len(ts) > 0 {
@@ -444,6 +536,13 @@ func (m *MessageContent) MergeContentDelta(mc MessageContent) {
 			ID:   mc.MessageContentToolUse.ID,
 			Name: mc.MessageContentToolUse.Name,
 		}
+	case MessagesContentTypeServerToolUse:
+		m.MessageContentServerToolUse = &MessageContentServerToolUse{
+			ID:   mc.MessageContentServerToolUse.ID,
+			Name: mc.MessageContentServerToolUse.Name,
+		}
+	case MessagesContentTypeWebSearchToolResult:
+		m.MessageContentWebSearchToolResult = mc.MessageContentWebSearchToolResult
 	case MessagesContentTypeInputJsonDelta:
 		if m.PartialJson == nil {
 			m.PartialJson = mc.PartialJson
@@ -493,6 +592,43 @@ func NewMessageContentToolResult(
 	}
 }
 
+type WebSearchResultType string
+
+const (
+	WebSearchResultTypeWebSearchResult WebSearchResultType = "web_search_result"
+)
+
+type WebSearchResult struct {
+	Type             WebSearchResultType `json:"type"`
+	Url              *string             `json:"url,omitempty"`
+	Title            *string             `json:"title,omitempty"`
+	EncryptedContent *string             `json:"encrypted_content,omitempty"`
+	PageAge          *string             `json:"page_age,omitempty"`
+}
+
+func NewWebSearchResult(url, title string) WebSearchResult {
+	return WebSearchResult{
+		Type:  WebSearchResultTypeWebSearchResult,
+		Url:   &url,
+		Title: &title,
+	}
+}
+
+type MessageContentWebSearchToolResult struct {
+	ToolUseID *string           `json:"tool_use_id,omitempty"`
+	Content   []WebSearchResult `json:"content,omitempty"`
+}
+
+func NewMessageContentWebSearchToolResult(
+	toolUseID string,
+	content []WebSearchResult,
+) *MessageContentWebSearchToolResult {
+	return &MessageContentWebSearchToolResult{
+		ToolUseID: &toolUseID,
+		Content:   content,
+	}
+}
+
 type MessageContentSource struct {
 	Type      MessagesContentSourceType `json:"type"`
 	MediaType string                    `json:"media_type,omitempty"`
@@ -534,6 +670,31 @@ func NewMessageContentToolUse(
 	}
 }
 
+func (c *MessageContentServerToolUse) UnmarshalInput(v any) error {
+	return json.Unmarshal(c.Input, v)
+}
+
+type MessageContentServerToolUse struct {
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+func NewMessageContentServerToolUse(
+	toolUseId, name string,
+	input json.RawMessage,
+) *MessageContentServerToolUse {
+	if input == nil {
+		input = json.RawMessage(`{}`)
+	}
+
+	return &MessageContentServerToolUse{
+		ID:    toolUseId,
+		Name:  name,
+		Input: input,
+	}
+}
+
 func (c *MessageContentToolUse) UnmarshalInput(v any) error {
 	return json.Unmarshal(c.Input, v)
 }
@@ -568,6 +729,10 @@ func (m MessagesResponse) GetFirstContentText() string {
 	return m.Content[0].GetText()
 }
 
+type ServerToolUsage struct {
+	WebSearchRequests int `json:"web_search_requests,omitempty"`
+}
+
 type MessagesUsage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
@@ -578,11 +743,27 @@ type MessagesUsage struct {
 	CacheReadInputTokens int `json:"cache_read_input_tokens,omitempty"`
 	// docs: https://platform.claude.com/docs/en/api/messages/create#message.usage + (resource) messages.cache_creation
 	CacheCreation MessageUsageCacheCreation `json:"cache_creation"`
+
+	ServerToolUse *ServerToolUsage `json:"server_tool_use,omitempty"`
 }
 
 type MessageUsageCacheCreation struct {
 	Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens"`
 	Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens"`
+}
+
+type UserLocationType string
+
+const (
+	UserLocationTypeApproximate = "approximate"
+)
+
+type UserLocation struct {
+	Type     UserLocationType `json:"type"`
+	City     string           `json:"city,omitempty"`
+	Region   string           `json:"region,omitempty"`
+	Country  string           `json:"country,omitempty"`
+	Timezone string           `json:"timezone,omitempty"`
 }
 
 type ToolDefinition struct {
@@ -609,6 +790,13 @@ type ToolDefinition struct {
 	DisplayHeightPx int `json:"display_height_px,omitempty"`
 	// DisplayNumber is an optional parameter of the Computer Use tool.
 	DisplayNumber *int `json:"display_number,omitempty"`
+
+	// Required for web search tool configuration.
+	MaxUses           *int          `json:"max_uses,omitempty"`
+	AllowedDomains    []string      `json:"allowed_domains,omitempty"`
+	BlockedDomains    []string      `json:"blocked_domains,omitempty"`
+	UserLocation      *UserLocation `json:"user_location,omitempty"`
+	ResponseInclusion *string       `json:"response_inclusion,omitempty"`
 }
 
 func NewComputerUseToolDefinition(

--- a/message_stream.go
+++ b/message_stream.go
@@ -266,9 +266,20 @@ func (c *Client) CreateMessagesStream(
 				}
 				if len(response.Content) > d.Index {
 					stopContent = response.Content[d.Index]
-					if stopContent.Type == MessagesContentTypeToolUse {
+					switch stopContent.Type {
+					case MessagesContentTypeToolUse:
 						if stopContent.PartialJson != nil {
-							stopContent.Input = json.RawMessage(*stopContent.PartialJson)
+							stopContent.MessageContentToolUse.Input = json.RawMessage(
+								*stopContent.PartialJson,
+							)
+						}
+						stopContent.PartialJson = nil
+						response.Content[d.Index] = stopContent
+					case MessagesContentTypeServerToolUse:
+						if stopContent.PartialJson != nil {
+							stopContent.MessageContentServerToolUse.Input = json.RawMessage(
+								*stopContent.PartialJson,
+							)
 						}
 						stopContent.PartialJson = nil
 						response.Content[d.Index] = stopContent

--- a/message_test.go
+++ b/message_test.go
@@ -1191,3 +1191,182 @@ func handleMessagesEndpoint(headers map[string]string) func(http.ResponseWriter,
 		_, _ = w.Write(resBytes)
 	}
 }
+
+func TestMessagesWebSearch(t *testing.T) {
+
+	server := test.NewTestServer()
+	server.RegisterHandler("/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		var req anthropic.MessagesRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		// Check if this is a request with web search tool results
+		hasWebSearchResult := false
+		for _, msg := range req.Messages {
+			for _, content := range msg.Content {
+				if content.Type == anthropic.MessagesContentTypeWebSearchToolResult {
+					hasWebSearchResult = true
+					break
+				}
+			}
+		}
+
+		var responseJSON string
+
+		if hasWebSearchResult {
+			// Final response with citations - build JSON manually to handle citations field correctly
+			responseJSON = `{
+				"id": "msg_01ABC123",
+				"type": "message",
+				"role": "assistant",
+				"model": "` + string(req.Model) + `",
+				"content": [{
+					"type": "text",
+					"text": "Go is a statically typed, compiled programming language designed at Google",
+					"citations": [{
+						"type": "web_search_result_location",
+						"url": "https://en.wikipedia.org/wiki/Go_(programming_language)",
+						"title": "Go (programming language) - Wikipedia",
+						"cited_text": "Go is a statically typed, compiled programming language designed at Google",
+						"encrypted_index": "encrypted_index_abc123"
+					}]
+				}],
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 100,
+					"output_tokens": 200,
+					"server_tool_use": {
+						"web_search_requests": 1
+					}
+				}
+			}`
+		} else {
+			// Initial response with server_tool_use and web_search_tool_result
+			responseJSON = `{
+				"id": "msg_01ABC123",
+				"type": "message",
+				"role": "assistant",
+				"model": "` + string(req.Model) + `",
+				"content": [
+					{
+						"type": "text",
+						"text": "I'll search for information about the Go programming language."
+					},
+					{
+						"type": "server_tool_use",
+						"id": "srvtoolu_01ABC123",
+						"name": "web_search",
+						"input": {"query": "what is go programming language"}
+					},
+					{
+						"type": "web_search_tool_result",
+						"tool_use_id": "srvtoolu_01ABC123",
+						"content": [{
+							"type": "web_search_result",
+							"url": "https://en.wikipedia.org/wiki/Go_(programming_language)",
+							"title": "Go (programming language) - Wikipedia",
+							"encrypted_content": "encrypted_content_xyz789",
+							"page_age": "2025-06-01"
+						}]
+					}
+				],
+				"stop_reason": "pause_turn",
+				"usage": {
+					"input_tokens": 100,
+					"output_tokens": 200
+				}
+			}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responseJSON))
+	})
+
+	ts := server.AnthropicTestServer()
+	ts.Start()
+	defer ts.Close()
+
+	baseUrl := ts.URL + "/v1"
+	client := anthropic.NewClient(
+		test.GetTestToken(),
+		anthropic.WithBaseURL(baseUrl),
+	)
+
+	request := anthropic.MessagesRequest{
+		Model: anthropic.ModelClaude3Haiku20240307,
+		Messages: []anthropic.Message{
+			anthropic.NewUserTextMessage("What is the Go programming language?"),
+		},
+		MaxTokens: 1000,
+		Tools: []anthropic.ToolDefinition{
+			{
+				Type: "web_search_20250305",
+				Name: "web_search",
+			},
+		},
+	}
+
+	// First request - Claude decides to search
+	resp, err := client.CreateMessages(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StopReason != anthropic.MessagesStopReasonPauseTurn {
+		t.Fatalf("Expected stop_reason pause_turn, got: %s", resp.StopReason)
+	}
+
+	// Find the web search result to send back
+	var webSearchResult *anthropic.MessageContent
+	for i, c := range resp.Content {
+		if c.Type == anthropic.MessagesContentTypeWebSearchToolResult {
+			webSearchResult = &resp.Content[i]
+		}
+	}
+
+	if webSearchResult == nil {
+		t.Fatal("web_search_tool_result not found in response")
+	}
+
+	// Add the assistant's response to the conversation
+	request.Messages = append(request.Messages, anthropic.Message{
+		Role:    anthropic.RoleAssistant,
+		Content: resp.Content,
+	})
+
+	// Second request - Continue with the search results
+	resp, err = client.CreateMessages(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Final response: %+v", resp)
+
+	// Verify we got citations in the final response
+	var hasCitations bool
+	for _, content := range resp.Content {
+		if len(content.Citations) > 0 {
+			hasCitations = true
+			for _, citation := range content.Citations {
+				if citation.Type == anthropic.CitationTypeWebSearchResultLocation {
+					t.Logf("Citation: %s - %s", *citation.Url, *citation.Title)
+				}
+			}
+		}
+	}
+
+	if !hasCitations {
+		t.Fatal("Expected citations in final response")
+	}
+
+	// Verify usage tracking
+	if resp.Usage.ServerToolUse == nil {
+		t.Fatal("Expected ServerToolUse in usage tracking")
+	}
+
+	if resp.Usage.ServerToolUse.WebSearchRequests != 1 {
+		t.Fatalf(
+			"Expected 1 web search request, got: %d",
+			resp.Usage.ServerToolUse.WebSearchRequests,
+		)
+	}
+}


### PR DESCRIPTION
This pull request adds support for the web-search tool to the SDK. Specifically, it allows the SDK to handle the `web_search_tool_result` and `server_tool_use` `MessageContent` types. Allowing users of the SDK to know when server tools are called and enabling them to access the search results directly.

To support this change, a test suite has been added to verify the SDK's ability to handle these new blocks. To allow the test to be written, the custom JSON unmarshaller has been updated to populate the nested objects in the `MessageContent` struct.