### PR TITLE
fix: correct JSON tag for MetaData field in CompleteRequest

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -14,7 +14,7 @@ type CompleteRequest struct {
 	Temperature   *float32       `json:"temperature,omitempty"`
 	TopP          *float32       `json:"top_p,omitempty"`
 	TopK          *int           `json:"top_k,omitempty"`
-	MetaData      map[string]any `json:"meta_data,omitempty"`
+	MetaData      map[string]any `json:"metadata,omitempty"`
 	Stream        bool           `json:"stream,omitempty"`
 }
 


### PR DESCRIPTION
The field was tagged `meta_data` but the Anthropic API expects `metadata`, causing metadata to be silently dropped on all Completions API requests.

See https://platform.claude.com/docs/en/api/messages/create