### PR TITLE
fix: remove omitempty from required fields Model and MaxTokens

### DIFF
--- a/message.go
+++ b/message.go
@@ -89,10 +89,10 @@ type DocumentCitations struct {
 }
 
 type MessagesRequest struct {
-	Model            Model     `json:"model,omitempty"`
+	Model            Model     `json:"model"`
 	AnthropicVersion string    `json:"anthropic_version,omitempty"`
 	Messages         []Message `json:"messages"`
-	MaxTokens        int       `json:"max_tokens,omitempty"`
+	MaxTokens        int       `json:"max_tokens"`
 
 	System        string              `json:"-"`
 	MultiSystem   []MessageSystemPart `json:"-"`


### PR DESCRIPTION
Both fields `Model` and `MaxTokens` are required by the Anthropic API. With omitempty, a zero value (empty string / 0) silently omits them from the request body, resulting in a confusing API error rather than a clear client-side signal.

`MaxTokens` of 0 actually has a meaningful use -- "Set to 0 to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response."

See https://platform.claude.com/docs/en/api/messages/create