### PR TITLE
fix: avoid typed nil error from returning *APIError as error interface

### DIFF
--- a/complete_stream.go
+++ b/complete_stream.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -90,7 +91,10 @@ func (c *Client) CreateCompleteStream(
 				if request.OnError != nil {
 					request.OnError(d)
 				}
-				return response, d.Error
+				if d.Error != nil {
+					return response, d.Error
+				}
+				return response, fmt.Errorf("stream error event with no error detail")
 			case CompleteEventPing:
 				var d CompleteStreamPingData
 				if err := json.Unmarshal(data, &d); err != nil {

--- a/message_stream.go
+++ b/message_stream.go
@@ -202,7 +202,10 @@ func (c *Client) CreateMessagesStream(
 				if request.OnError != nil {
 					request.OnError(eventData)
 				}
-				return response, eventData.Error
+				if eventData.Error != nil {
+					return response, eventData.Error
+				}
+				return response, fmt.Errorf("stream error event with no error detail")
 			case MessagesEventPing:
 				var d MessagesEventPingData
 				if err := json.Unmarshal(data, &d); err != nil {


### PR DESCRIPTION
This PR is fundamentally some hardening around how we return errors.

Returning a `nil` `*APIError` directly as the error interface produces a non-`nil` interface value (type information present, nil pointer), causing callers to see `err != nil` but `panic` on `err.Error()`. Guard both sites (message_stream.go and complete_stream.go) with an explicit `nil` check, and return a sentinel error if an error event arrives with no payload.