### PR TITLE
fix: avoid trailing ? in ListBatches URL when no query params given

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -254,7 +254,9 @@ func (c *Client) ListBatches(
 	}
 
 	// encode the query parameters into the URL
-	urlSuffix += "?" + v.Encode()
+	if encoded := v.Encode(); encoded != "" {
+		urlSuffix += "?" + encoded
+	}
 	req, err := c.newRequest(ctx, http.MethodGet, urlSuffix, nil, setters...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When no pagination parameters are set, `v.Encode()` returns an empty string, resulting in a URL like `/messages/batches?` which some servers reject. This change makes us only append the query string when there are parameters.