### PR TITLE
fix: handle error return from SetRequestHeaders adapter call

### DIFF
--- a/client.go
+++ b/client.go
@@ -138,7 +138,9 @@ func (c *Client) newRequest(
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 
 	// set any provider-specific headers (including Authorization)
-	c.config.Adapter.SetRequestHeaders(c, req)
+	if err := c.config.Adapter.SetRequestHeaders(c, req); err != nil {
+		return nil, err
+	}
 
 	for _, setter := range requestSetters {
 		setter(req)


### PR DESCRIPTION
The `ClientAdapter.SetRequestHeaders` interface method returns an error, but the call site in `newRequest` was silently discarding it. This means auth failures or header-setting errors would go undetected, causing downstream HTTP 401s with no clear cause.