### PR TITLE
fix: guard nil MessageContentToolUse/ServerToolUse in content_block_stop

### DIFF
--- a/message_stream.go
+++ b/message_stream.go
@@ -268,7 +268,7 @@ func (c *Client) CreateMessagesStream(
 					stopContent = response.Content[d.Index]
 					switch stopContent.Type {
 					case MessagesContentTypeToolUse:
-						if stopContent.PartialJson != nil {
+						if stopContent.PartialJson != nil && stopContent.MessageContentToolUse != nil {
 							stopContent.MessageContentToolUse.Input = json.RawMessage(
 								*stopContent.PartialJson,
 							)
@@ -276,7 +276,7 @@ func (c *Client) CreateMessagesStream(
 						stopContent.PartialJson = nil
 						response.Content[d.Index] = stopContent
 					case MessagesContentTypeServerToolUse:
-						if stopContent.PartialJson != nil {
+						if stopContent.PartialJson != nil && stopContent.MessageContentServerToolUse != nil {
 							stopContent.MessageContentServerToolUse.Input = json.RawMessage(
 								*stopContent.PartialJson,
 							)


### PR DESCRIPTION
When a `content_block_stop` event arrives for a tool-use or server-tool-use block, the handler assigns accumulated `PartialJson` into the `Input` field. However, it only checks `PartialJson` for `nil` while not checking the `MessageContentToolUse`/`MessageContentServerToolUse` pointer itself, which can be `nil` if the content block was never fully initialised, causing a panic.