### PR TITLE
fix: stop sending max_tokens on count_tokens requests

### DIFF
--- a/count_tokens.go
+++ b/count_tokens.go
@@ -11,6 +11,47 @@ type CountTokensResponse struct {
 	InputTokens int `json:"input_tokens"`
 }
 
+// countTokensRequest is the restricted body sent to the count_tokens
+// endpoint. The endpoint only accepts a subset of the message creation
+// fields and rejects any extra inputs (e.g. max_tokens) with a 400. We
+// therefore serialize only the permitted fields here rather than reusing
+// MessagesRequest, whose max_tokens field has no omitempty and would always
+// be present.
+type countTokensRequest struct {
+	Model    Model       `json:"model"`
+	Messages []Message   `json:"messages"`
+	System   interface{} `json:"system,omitempty"`
+
+	Tools        []ToolDefinition     `json:"tools,omitempty"`
+	ToolChoice   *ToolChoice          `json:"tool_choice,omitempty"`
+	Thinking     *Thinking            `json:"thinking,omitempty"`
+	CacheControl *MessageCacheControl `json:"cache_control,omitempty"`
+	OutputConfig *OutputConfig        `json:"output_config,omitempty"`
+}
+
+// newCountTokensRequest builds the restricted count_tokens body from a
+// MessagesRequest, preserving the system / multi-system handling that
+// MessagesRequest.MarshalJSON performs.
+func newCountTokensRequest(request MessagesRequest) countTokensRequest {
+	body := countTokensRequest{
+		Model:        request.Model,
+		Messages:     request.Messages,
+		Tools:        request.Tools,
+		ToolChoice:   request.ToolChoice,
+		Thinking:     request.Thinking,
+		CacheControl: request.CacheControl,
+		OutputConfig: request.OutputConfig,
+	}
+
+	if len(request.MultiSystem) > 0 {
+		body.System = request.MultiSystem
+	} else if len(request.System) > 0 {
+		body.System = request.System
+	}
+
+	return body
+}
+
 func (c *Client) CountTokens(
 	ctx context.Context,
 	request MessagesRequest,
@@ -20,8 +61,10 @@ func (c *Client) CountTokens(
 		setters = append(setters, withBetaVersion(c.config.BetaVersion...))
 	}
 
+	body := newCountTokensRequest(request)
+
 	urlSuffix := "/messages/count_tokens"
-	req, err := c.newRequest(ctx, http.MethodPost, urlSuffix, &request, setters...)
+	req, err := c.newRequest(ctx, http.MethodPost, urlSuffix, &body, setters...)
 	if err != nil {
 		return
 	}

--- a/count_tokens_test.go
+++ b/count_tokens_test.go
@@ -3,6 +3,7 @@ package anthropic_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,32 +46,52 @@ func TestCountTokens(t *testing.T) {
 		t.Logf("CountTokens resp: %+v", resp)
 	})
 
-	t.Run("count tokens failure", func(t *testing.T) {
-		request.MaxTokens = 10
-		_, err := client.CountTokens(context.Background(), request)
-		if err == nil {
-			t.Fatalf("CountTokens expected error, got nil")
+	t.Run("count tokens omits max_tokens even when set", func(t *testing.T) {
+		// The count_tokens endpoint rejects max_tokens. Even if the caller
+		// populates MaxTokens on the MessagesRequest, the SDK must not send
+		// it. The mock handler 400s if the raw body carries max_tokens.
+		req := request
+		req.MaxTokens = 10
+		resp, err := client.CountTokens(context.Background(), req)
+		if err != nil {
+			t.Fatalf("CountTokens error: %v", err)
 		}
 
-		t.Logf("CountTokens error: %v", err)
+		t.Logf("CountTokens resp: %+v", resp)
 	})
 }
 
 func handleCountTokens(w http.ResponseWriter, r *http.Request) {
-	var err error
 	var resBytes []byte
 
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 
-	var req anthropic.MessagesRequest
-	if req, err = getRequest[anthropic.MessagesRequest](r); err != nil {
+	rawBody, err := io.ReadAll(r.Body)
+	if err != nil {
 		http.Error(w, "could not read request", http.StatusInternalServerError)
 		return
 	}
-	if req.MaxTokens > 0 {
+
+	// The count_tokens endpoint rejects extra inputs such as max_tokens.
+	// Inspect the raw bytes so an always-present "max_tokens":0 cannot slip
+	// through. The endpoint returns 400 "Extra inputs are not permitted".
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rawBody, &raw); err != nil {
+		http.Error(w, "could not read request", http.StatusInternalServerError)
+		return
+	}
+	if _, ok := raw["max_tokens"]; ok {
 		http.Error(w, "max_tokens: Extra inputs are not permitted", http.StatusBadRequest)
+		return
+	}
+	if _, ok := raw["model"]; !ok {
+		http.Error(w, "model: Field required", http.StatusBadRequest)
+		return
+	}
+	if _, ok := raw["messages"]; !ok {
+		http.Error(w, "messages: Field required", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
## Problem

Every `CountTokens` call fails against the live API with a 400:

```
max_tokens: Extra inputs are not permitted
```

`CountTokens` marshals a full `MessagesRequest` to `POST /v1/messages/count_tokens`, but that endpoint accepts only a subset of fields (`model`, `messages`, `system`, `tools`, `tool_choice`, `thinking`, `cache_control`, `output_config`) and rejects any extras.

## Root cause

This is a regression from #117 ("remove omitempty from required fields Model and MaxTokens"). That change is correct for the Messages API — but with `omitempty` gone, `MaxTokens` is now always serialized, so every `count_tokens` request carries `"max_tokens":0`, which the endpoint rejects. (Before #117 the zero value was dropped by `omitempty`, so `count_tokens` happened to work.)

The existing test didn't catch it because the mock only rejected `req.MaxTokens > 0`, so the always-present `"max_tokens":0` slipped through.

## Fix

- Build a dedicated, restricted request body for `count_tokens` that contains only the permitted fields, instead of reusing `MessagesRequest` verbatim. The public `CountTokens(ctx, MessagesRequest)` signature is unchanged, and the `system` / multi-system handling is preserved.
- Update the mock in `count_tokens_test.go` to inspect the raw request bytes and assert `max_tokens` is absent (and `model`/`messages` present), so the regression can't slip back in unnoticed.

`go build`, the full test suite, `go vet`, and `gofmt` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
