### PR TITLE
fix: tool_use / tool_result blocks serialize without their fields

### DIFF
--- a/message.go
+++ b/message.go
@@ -290,6 +290,65 @@ type MessageContent struct {
 	*MessageContentRedactedThinking
 }
 
+// MarshalJSON implements custom JSON marshaling for MessageContent.
+//
+// MessageContent embeds several pointer structs (tool_use, server_tool_use,
+// tool_result, web_search_tool_result) that declare overlapping JSON field
+// names — for example both MessageContentToolResult and
+// MessageContentWebSearchToolResult define "tool_use_id" and "content", and
+// both MessageContentToolUse and MessageContentServerToolUse define "id",
+// "name" and "input". Go's encoding/json drops fields that are ambiguous across
+// embedded structs at the same depth, which would silently strip "tool_use_id",
+// "content", "id", "name" and "input" from the wire payload.
+//
+// To produce a correct payload we marshal the base struct (which omits the
+// ambiguous fields) and then merge back the fields of whichever embedded tool
+// struct is actually populated. Blocks without an ambiguous embedded struct
+// (text, image, document, thinking, …) are marshaled exactly as before.
+func (m MessageContent) MarshalJSON() ([]byte, error) {
+	type Alias MessageContent
+	base, err := json.Marshal(Alias(m))
+	if err != nil {
+		return nil, err
+	}
+
+	var extra any
+	switch {
+	case m.MessageContentToolResult != nil:
+		extra = m.MessageContentToolResult
+	case m.MessageContentToolUse != nil:
+		extra = m.MessageContentToolUse
+	case m.MessageContentServerToolUse != nil:
+		extra = m.MessageContentServerToolUse
+	case m.MessageContentWebSearchToolResult != nil:
+		extra = m.MessageContentWebSearchToolResult
+	}
+
+	if extra == nil {
+		// No ambiguous embedded struct; preserve the original encoding.
+		return base, nil
+	}
+
+	merged := map[string]json.RawMessage{}
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+
+	extraBytes, err := json.Marshal(extra)
+	if err != nil {
+		return nil, err
+	}
+	extraFields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(extraBytes, &extraFields); err != nil {
+		return nil, err
+	}
+	for k, v := range extraFields {
+		merged[k] = v
+	}
+
+	return json.Marshal(merged)
+}
+
 // UnmarshalJSON implements custom JSON unmarshaling for MessageContent
 func (m *MessageContent) UnmarshalJSON(data []byte) error {
 	// First, unmarshal to get the type field

--- a/message_toolblock_marshal_test.go
+++ b/message_toolblock_marshal_test.go
@@ -1,0 +1,62 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/liushuangls/go-anthropic/v2"
+)
+
+// MessageContent embeds multiple pointer structs with overlapping JSON tags
+// (tool_use_id/content on tool_result + web_search_tool_result; id/name/input on
+// tool_use + server_tool_use). Without a custom MarshalJSON, Go's encoding/json
+// drops those ambiguous promoted fields, so tool blocks serialize empty and the
+// API never receives them. These tests lock in correct serialization.
+
+func TestToolResultMarshalIncludesFields(t *testing.T) {
+	b, err := json.Marshal(anthropic.NewToolResultMessageContent("toolu_123", "the result", false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"type":"tool_result"`, `"tool_use_id":"toolu_123"`, `"content"`, `the result`} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("tool_result marshal missing %q: %s", want, b)
+		}
+	}
+}
+
+func TestToolUseMarshalIncludesFields(t *testing.T) {
+	b, err := json.Marshal(anthropic.NewToolUseMessageContent("toolu_123", "get_weather", json.RawMessage(`{"city":"NYC"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"type":"tool_use"`, `"id":"toolu_123"`, `"name":"get_weather"`, `"input"`, `"city":"NYC"`} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("tool_use marshal missing %q: %s", want, b)
+		}
+	}
+}
+
+func TestServerToolUseMarshalIncludesFields(t *testing.T) {
+	b, err := json.Marshal(anthropic.NewServerToolUseContent("srvtoolu_1", "web_search", json.RawMessage(`{"query":"golang"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"id":"srvtoolu_1"`, `"name":"web_search"`, `"query":"golang"`} {
+		if !strings.Contains(string(b), want) {
+			t.Errorf("server_tool_use marshal missing %q: %s", want, b)
+		}
+	}
+}
+
+// Non-tool blocks must keep their original encoding.
+func TestTextBlockMarshalUnchanged(t *testing.T) {
+	b, err := json.Marshal(anthropic.NewTextMessageContent("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"type":"text"`) || !strings.Contains(string(b), `"text":"hello"`) {
+		t.Errorf("text block marshal changed unexpectedly: %s", b)
+	}
+}

--- a/message_toolblock_marshal_test.go
+++ b/message_toolblock_marshal_test.go
@@ -27,7 +27,13 @@ func TestToolResultMarshalIncludesFields(t *testing.T) {
 }
 
 func TestToolUseMarshalIncludesFields(t *testing.T) {
-	b, err := json.Marshal(anthropic.NewToolUseMessageContent("toolu_123", "get_weather", json.RawMessage(`{"city":"NYC"}`)))
+	b, err := json.Marshal(
+		anthropic.NewToolUseMessageContent(
+			"toolu_123",
+			"get_weather",
+			json.RawMessage(`{"city":"NYC"}`),
+		),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +45,13 @@ func TestToolUseMarshalIncludesFields(t *testing.T) {
 }
 
 func TestServerToolUseMarshalIncludesFields(t *testing.T) {
-	b, err := json.Marshal(anthropic.NewServerToolUseContent("srvtoolu_1", "web_search", json.RawMessage(`{"query":"golang"}`)))
+	b, err := json.Marshal(
+		anthropic.NewServerToolUseContent(
+			"srvtoolu_1",
+			"web_search",
+			json.RawMessage(`{"query":"golang"}`),
+		),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +68,8 @@ func TestTextBlockMarshalUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(b), `"type":"text"`) || !strings.Contains(string(b), `"text":"hello"`) {
+	if !strings.Contains(string(b), `"type":"text"`) ||
+		!strings.Contains(string(b), `"text":"hello"`) {
 		t.Errorf("text block marshal changed unexpectedly: %s", b)
 	}
 }


### PR DESCRIPTION
## Problem

`MessageContent` blocks for tool use and tool results serialize with their load-bearing fields **silently dropped**:

```go
b, _ := json.Marshal(anthropic.NewToolResultMessageContent("toolu_123", "the result", false))
// {"type":"tool_result","is_error":false}          ← no tool_use_id, no content

b, _ = json.Marshal(anthropic.NewToolUseMessageContent("toolu_123", "get_weather", json.RawMessage(`{"city":"NYC"}`)))
// {"type":"tool_use"}                                ← no id, name, or input
```

`tool_use_id`, `content`, `id`, `name` and `input` never reach the wire. Per the [Messages API docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls), `tool_use_id` is **required** on a `tool_result` and `id`/`name`/`input` are **required** on a `tool_use`; because those are dropped, **every multi-turn tool-use / function-calling round-trip is rejected by the API with a 400.** (`content` and `is_error` are optional, but they were dropped too.)

## Root cause

`MessageContent` embeds several pointer structs that declare overlapping JSON field names:

- `*MessageContentToolResult` and `*MessageContentWebSearchToolResult` both define `tool_use_id` and `content`
- `*MessageContentToolUse` and `*MessageContentServerToolUse` both define `id`, `name` and `input`

Go's `encoding/json` treats fields promoted from embedded structs **at the same depth** with the same JSON name as ambiguous and omits them from the output entirely — regardless of which embedded pointer is non-nil at runtime. The individual struct tags are all correct; the bug is the embedding, so it isn't visible from reading the tags, and no existing test asserted the marshaled bytes.

## Fix

Add a `MessageContent.MarshalJSON` that marshals the base struct (which omits the ambiguous fields) and then merges back the fields of whichever tool struct is actually populated. Blocks without an ambiguous embedded struct (text, image, document, thinking, …) are encoded exactly as before, so the blast radius is limited to the tool blocks that are currently broken.

After the fix:

```
tool_result -> {"content":[{"type":"text","text":"the result"}],"is_error":false,"tool_use_id":"toolu_123","type":"tool_result"}
tool_use    -> {"id":"toolu_123","input":{"city":"NYC"},"name":"get_weather","type":"tool_use"}
```

These shapes match the documented Messages API: a `tool_result`'s `content` may be a string or an array of `text`/`image`/`document` blocks, and a `tool_use` carries `id`/`name`/`input`.

Adds tests asserting the wire payload for `tool_result`, `tool_use` and `server_tool_use`, and that a plain text block is unchanged. `go build`, `go test ./...`, `go vet`, and `gofmt` are all clean.

## References (Anthropic Messages API documentation)

- [Tool use overview](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) — the `tool_use` block shape: `type`, `id`, `name`, `input`.
- [Handle tool calls](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) — the `tool_result` block: `tool_use_id` (required); `content` (optional — a string or an array of `text`/`image`/`document`/`search_result` blocks); `is_error` (optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
