### PR TITLE
fix: bound streaming content block index to prevent OOM/panic

### DIFF
--- a/message_stream.go
+++ b/message_stream.go
@@ -332,8 +332,14 @@ func growMessageContent(content []MessageContent, index int) []MessageContent {
 	return content
 }
 
+// maxStreamContentBlockIndex caps the content block index accepted from the
+// wire. The index is attacker/server controlled; an absurdly large value would
+// otherwise force growMessageContent to allocate a gigantic slice (OOM) or
+// panic in makeslice. Real responses never approach this bound.
+const maxStreamContentBlockIndex = 100000
+
 func validateMessageContentIndex(index int) error {
-	if index < 0 {
+	if index < 0 || index > maxStreamContentBlockIndex {
 		return fmt.Errorf("invalid content block index: %d", index)
 	}
 	return nil

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -694,6 +694,61 @@ func handlerMessagesStreamNegativeContentBlockStopIndex(w http.ResponseWriter, r
 	)
 }
 
+func TestCreateMessagesStreamReturnsErrorForAbsurdContentBlockIndexes(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "content_block_start",
+			data: `{"type":"content_block_start","index":1000000000,"content_block":{"type":"text","text":""}}`,
+		},
+		{
+			name: "content_block_delta",
+			data: `{"type":"content_block_delta","index":1000000000,"delta":{"type":"text_delta","text":"x"}}`,
+		},
+		{
+			name: "content_block_stop",
+			data: `{"type":"content_block_stop","index":1000000000}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := test.NewTestServer()
+			server.RegisterHandler("/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+				writeMessagesStreamWithNegativeContentBlockIndex(w, tt.name, tt.data)
+			})
+
+			ts := server.AnthropicTestServer()
+			ts.Start()
+			defer ts.Close()
+
+			baseUrl := ts.URL + "/v1"
+			client := anthropic.NewClient(
+				test.GetTestToken(),
+				anthropic.WithBaseURL(baseUrl),
+			)
+
+			_, err := client.CreateMessagesStream(
+				context.Background(),
+				anthropic.MessagesStreamRequest{
+					MessagesRequest: anthropic.MessagesRequest{
+						Model: anthropic.ModelClaude3Haiku20240307,
+						Messages: []anthropic.Message{
+							anthropic.NewUserTextMessage("What is your name?"),
+						},
+						MaxTokens: 1000,
+					},
+				},
+			)
+			if err == nil {
+				t.Fatalf("CreateMessagesStream expect error for absurd index, but got nil")
+			}
+		})
+	}
+}
+
 func writeMessagesStreamWithNegativeContentBlockIndex(w http.ResponseWriter, event, data string) {
 	w.Header().Set("Content-Type", "text/event-stream")
 


### PR DESCRIPTION
\`validateMessageContentIndex\` only rejected negative indexes. A server-controlled \`content_block_start\`/\`delta\`/\`stop\` event with an absurdly large index (e.g. 1e9) would flow into \`growMessageContent\`, which grows the content slice to that size — an OOM or a panic in \`makeslice\` on attacker/server-influenced input.

This caps the accepted index at a generous bound (100,000) that real responses never approach, and returns an error instead.

Added a test covering all three event types with an out-of-range index.