### PR TITLE
fix: correct page citation discriminator and field tags

### DIFF
--- a/message.go
+++ b/message.go
@@ -36,7 +36,7 @@ type CitationType string
 
 const (
 	CitationTypeCharLocation            CitationType = "char_location"
-	CitationTypePageNumber              CitationType = "page_number"
+	CitationTypePageLocation            CitationType = "page_location"
 	CitationTypeBlockIndex              CitationType = "block_index"
 	CitationTypeWebSearchResultLocation CitationType = "web_search_result_location"
 )
@@ -238,9 +238,9 @@ type Citation struct {
 	StartCharIndex *int `json:"start_char_index,omitempty"`
 	EndCharIndex   *int `json:"end_char_index,omitempty"`
 
-	// For page_number citations
-	StartPage *int `json:"start_page,omitempty"`
-	EndPage   *int `json:"end_page,omitempty"`
+	// For page_location citations
+	StartPage *int `json:"start_page_number,omitempty"`
+	EndPage   *int `json:"end_page_number,omitempty"`
 
 	// For block_index citations
 	StartBlockIndex *int `json:"start_block_index,omitempty"`

--- a/message_test.go
+++ b/message_test.go
@@ -1370,3 +1370,51 @@ func TestMessagesWebSearch(t *testing.T) {
 		)
 	}
 }
+
+func TestCitationTypePageLocation(t *testing.T) {
+	if anthropic.CitationTypePageLocation != "page_location" {
+		t.Fatalf("unexpected value: %q", anthropic.CitationTypePageLocation)
+	}
+
+	body := `{"type":"text","text":"x","citations":[{"type":"page_location","cited_text":"y","document_index":0}]}`
+	var mc anthropic.MessageContent
+	if err := json.Unmarshal([]byte(body), &mc); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(mc.Citations) != 1 {
+		t.Fatalf("expected 1 citation, got %d", len(mc.Citations))
+	}
+	if mc.Citations[0].Type != anthropic.CitationTypePageLocation {
+		t.Fatalf("unexpected citation type: %q", mc.Citations[0].Type)
+	}
+}
+
+func TestCitationPageNumberFields(t *testing.T) {
+	body := `{
+		"type": "text",
+		"text": "x",
+		"citations": [
+			{
+				"type": "page_location",
+				"cited_text": "y",
+				"document_index": 0,
+				"start_page_number": 3,
+				"end_page_number": 5
+			}
+		]
+	}`
+	var mc anthropic.MessageContent
+	if err := json.Unmarshal([]byte(body), &mc); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(mc.Citations) != 1 {
+		t.Fatalf("expected 1 citation, got %d", len(mc.Citations))
+	}
+	c := mc.Citations[0]
+	if c.StartPage == nil || *c.StartPage != 3 {
+		t.Fatalf("unexpected start_page_number: %v", c.StartPage)
+	}
+	if c.EndPage == nil || *c.EndPage != 5 {
+		t.Fatalf("unexpected end_page_number: %v", c.EndPage)
+	}
+}


### PR DESCRIPTION
Page citations are currently broken against the real API:

- The type discriminator was \`page_number\`; the API uses \`page_location\`.
- The JSON tags for the page range were \`start_page\`/\`end_page\`; the API uses \`start_page_number\`/\`end_page_number\`.

Combining both fixes in one PR since they're two halves of the same bug — fixing only one would still leave page citations unable to round-trip.