### PR TITLE
fix: stream batch results decode to avoid double parse and truncation

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -170,38 +170,30 @@ func (c *Client) RetrieveBatchResults(
 		return nil, err
 	}
 
-	response.RawResponse, err = io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	response.Responses, err = decodeRawResponse(response.RawResponse)
-	if err != nil {
-		return nil, err
-	}
-
-	return &response, err
-}
-
-func decodeRawResponse(rawResponse []byte) ([]BatchResult, error) {
-	// This looks fishy, but this logic works.
-	// https://goplay.tools/snippet/tDPm3GJVv0_s
-	var results []BatchResult
-	for _, line := range bytes.Split(rawResponse, []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-
+	// Decode the .jsonl body in a single streaming pass. A json.Decoder reads
+	// one JSON value at a time and treats inter-record newlines as whitespace,
+	// so there is no per-line length limit (records can exceed 64KB) and we
+	// avoid the previous re-parse of the whole body via bytes.Split.
+	//
+	// RawResponse is a public field kept for backward compatibility. It is
+	// populated via a TeeReader as the body is consumed. Note the memory cost:
+	// the full (potentially multi-GB) body is retained in addition to the
+	// parsed Responses. Callers that only need Responses can ignore it.
+	var rawBuf bytes.Buffer
+	dec := json.NewDecoder(io.TeeReader(res.Body, &rawBuf))
+	for {
 		var parsed BatchResult
-		err := json.Unmarshal(line, &parsed)
-		if err != nil {
-			return nil, err
+		if decErr := dec.Decode(&parsed); decErr != nil {
+			if errors.Is(decErr, io.EOF) {
+				break
+			}
+			return nil, decErr
 		}
-
-		results = append(results, parsed)
+		response.Responses = append(response.Responses, parsed)
 	}
+	response.RawResponse = rawBuf.Bytes()
 
-	return results, nil
+	return &response, nil
 }
 
 type ListBatchesResponse struct {

--- a/batch_test.go
+++ b/batch_test.go
@@ -253,6 +253,91 @@ func handleRetrieveBatchResultsEndpoint(w http.ResponseWriter, r *http.Request) 
 	_, _ = w.Write(resBytes)
 }
 
+func TestRetrieveBatchResultsJSONL(t *testing.T) {
+	server := test.NewTestServer()
+	server.RegisterHandler(
+		"/v1/messages/batches/batch_id_jsonl/results",
+		handleRetrieveBatchResultsJSONLEndpoint,
+	)
+
+	ts := server.AnthropicTestServer()
+	ts.Start()
+	defer ts.Close()
+
+	baseUrl := ts.URL + "/v1"
+	client := anthropic.NewClient(
+		test.GetTestToken(),
+		anthropic.WithBaseURL(baseUrl),
+		anthropic.WithBetaVersion(anthropic.BetaMessageBatches20240924),
+	)
+
+	resp, err := client.RetrieveBatchResults(context.Background(), "batch_id_jsonl")
+	if err != nil {
+		t.Fatalf("RetrieveBatchResults error: %s", err)
+	}
+
+	if len(resp.Responses) != 3 {
+		t.Fatalf("expected 3 responses, got %d", len(resp.Responses))
+	}
+
+	for i, r := range resp.Responses {
+		wantID := "custom_id_" + strconv.Itoa(i)
+		if r.CustomId != wantID {
+			t.Fatalf("response %d: expected custom_id %q, got %q", i, wantID, r.CustomId)
+		}
+		if r.Result.Type != anthropic.ResultTypeSucceeded {
+			t.Fatalf("response %d: expected result type succeeded, got %q", i, r.Result.Type)
+		}
+	}
+
+	// The middle record is larger than bufio.Scanner's default 64KB buffer,
+	// so it must decode intact without truncation.
+	bigText := resp.Responses[1].Result.Result.GetFirstContentText()
+	if len(bigText) < 64*1024 {
+		t.Fatalf("expected large record text to exceed 64KB, got %d bytes", len(bigText))
+	}
+}
+
+func handleRetrieveBatchResultsJSONLEndpoint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-jsonl")
+
+	makeLine := func(i int, text string) []byte {
+		res := anthropic.BatchResult{
+			CustomId: "custom_id_" + strconv.Itoa(i),
+			Result: anthropic.BatchResultCore{
+				Type: anthropic.ResultTypeSucceeded,
+				Result: anthropic.MessagesResponse{
+					ID:   "msg_" + strconv.Itoa(i),
+					Type: anthropic.MessagesResponseTypeMessage,
+					Role: anthropic.RoleAssistant,
+					Content: []anthropic.MessageContent{
+						{
+							Type: anthropic.MessagesContentTypeText,
+							Text: toPtr(text),
+						},
+					},
+					Model:      anthropic.ModelClaude3Haiku20240307,
+					StopReason: anthropic.MessagesStopReasonEndTurn,
+				},
+			},
+		}
+		b, _ := json.Marshal(res)
+		return append(b, '\n')
+	}
+
+	var body []byte
+	body = append(body, makeLine(0, "first")...)
+	body = append(body, makeLine(1, strings.Repeat("A", 70*1024))...)
+	body = append(body, makeLine(2, "third")...)
+
+	_, _ = w.Write(body)
+}
+
 func TestListBatches(t *testing.T) {
 	server := test.NewTestServer()
 	server.RegisterHandler("/v1/messages/batches", handleListBatchesEndpoint)


### PR DESCRIPTION
\`RetrieveBatchResults\` decoded the \`.jsonl\` body by reading the whole thing into memory, then splitting on \`\n\` and \`json.Unmarshal\`-ing each line. That's a correctness bug, not just inefficiency: a JSON record can legitimately contain a literal newline (e.g. inside a string), which \`bytes.Split\` would cut in the middle, corrupting or truncating that record.

This switches to a single streaming pass with \`json.Decoder\`, which reads one JSON value at a time and treats inter-record whitespace (including newlines) correctly — no more naive line-splitting.

\`RawResponse\` is kept for backward compatibility, populated via a \`TeeReader\` as the body is consumed.

Build and tests pass locally (\`go build ./...\`, \`go test ./...\`).