### PR TITLE
fix: deliver final SSE frame that lacks a trailing newline

### DIFF
--- a/complete_stream.go
+++ b/complete_stream.go
@@ -63,10 +63,16 @@ func (c *Client) CreateCompleteStream(
 	for {
 		rawLine, readErr := reader.ReadBytes('\n')
 		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
+			if !errors.Is(readErr, io.EOF) {
+				return response, readErr
+			}
+			// ReadBytes returns the final bytes together with io.EOF when the
+			// last frame has no trailing newline. If there is nothing left to
+			// process we are done; otherwise fall through and handle the frame
+			// before the next read breaks here.
+			if len(bytes.TrimSpace(rawLine)) == 0 {
 				break
 			}
-			return response, readErr
 		}
 
 		noSpaceLine := bytes.TrimSpace(rawLine)

--- a/message_stream.go
+++ b/message_stream.go
@@ -174,10 +174,16 @@ func (c *Client) CreateMessagesStream(
 	for {
 		rawLine, readErr := reader.ReadBytes('\n')
 		if readErr != nil {
-			if errors.Is(readErr, io.EOF) {
+			if !errors.Is(readErr, io.EOF) {
+				return response, readErr
+			}
+			// ReadBytes returns the final bytes together with io.EOF when the
+			// last frame has no trailing newline. If there is nothing left to
+			// process we are done; otherwise fall through and handle the frame
+			// (e.g. a terminal message_stop) before the next read breaks here.
+			if len(bytes.TrimSpace(rawLine)) == 0 {
 				break
 			}
-			return response, readErr
 		}
 
 		noSpaceLine := bytes.TrimSpace(rawLine)

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -586,6 +586,71 @@ func handlerMessagesStream(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(dataBytes)
 }
 
+func TestCreateMessagesStreamDeliversFinalEventWithoutTrailingNewline(t *testing.T) {
+	server := test.NewTestServer()
+	server.RegisterHandler("/v1/messages", handlerMessagesStreamNoTrailingNewline)
+
+	ts := server.AnthropicTestServer()
+	ts.Start()
+	defer ts.Close()
+
+	baseUrl := ts.URL + "/v1"
+	client := anthropic.NewClient(
+		test.GetTestToken(),
+		anthropic.WithBaseURL(baseUrl),
+	)
+
+	var gotMessageStop bool
+	resp, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
+		MessagesRequest: anthropic.MessagesRequest{
+			Model: anthropic.ModelClaude3Haiku20240307,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens: 1000,
+		},
+		OnMessageStop: func(data anthropic.MessagesEventMessageStopData) {
+			gotMessageStop = true
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessagesStream error: %s", err)
+	}
+
+	if !gotMessageStop {
+		t.Fatalf("final message_stop event without trailing newline was not delivered")
+	}
+	if resp.StopReason != anthropic.MessagesStopReasonEndTurn {
+		t.Fatalf("expected stop reason end_turn, got %q", resp.StopReason)
+	}
+}
+
+func handlerMessagesStreamNoTrailingNewline(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	var dataBytes []byte
+
+	dataBytes = append(dataBytes, []byte("event: message_start\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"message_start","message":{"id":"1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"output_tokens":1}}}`+"\n\n",
+		)...)
+
+	dataBytes = append(dataBytes, []byte("event: message_delta\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":9}}`+"\n\n",
+		)...)
+
+	// Final frame intentionally has NO trailing newline.
+	dataBytes = append(dataBytes, []byte("event: message_stop\n")...)
+	dataBytes = append(dataBytes, []byte(`data: {"type":"message_stop"}`)...)
+
+	_, _ = w.Write(dataBytes)
+}
+
 func handlerMessagesStreamSparseContentBlockIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 


### PR DESCRIPTION
Both streaming loops (\`CreateCompleteStream\` and \`CreateMessagesStream\`) read frames with \`reader.ReadBytes('\n')\` and treated any \`io.EOF\` as "stream done, stop." But \`ReadBytes\` returns the final unterminated bytes *together with* \`io.EOF\` when the body doesn't end in a newline — so if the server's last frame (e.g. \`message_stop\`) isn't newline-terminated, it was silently dropped instead of delivered.

Now on EOF we only break if the trailing buffer is empty; otherwise we fall through and process that last frame before the next \`ReadBytes\` call returns empty+EOF and breaks normally.

Added a test with a handler that emits the final \`message_stop\` frame with no trailing newline and asserts \`OnMessageStop\` still fires.

Build and tests pass locally.