### PR TITLE
fix: marshal response citations under the API "citations" key

### DIFF
--- a/citations_test.go
+++ b/citations_test.go
@@ -113,3 +113,57 @@ func strPtr(s string) *string {
 func intPtr(i int) *int {
 	return &i
 }
+
+func TestMessageContentCitationsRoundTrip(t *testing.T) {
+	input := `{
+		"type": "text",
+		"text": "the grass is green",
+		"citations": [
+			{
+				"type": "char_location",
+				"cited_text": "The grass is green.",
+				"document_index": 0,
+				"document_title": "My Document",
+				"start_char_index": 0,
+				"end_char_index": 20
+			}
+		]
+	}`
+
+	var mc MessageContent
+	if err := json.Unmarshal([]byte(input), &mc); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	assert.Len(t, mc.Citations, 1)
+
+	out, err := json.Marshal(mc)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Must emit the API key "citations", not the internal "citations_list".
+	assert.Contains(t, string(out), `"citations"`)
+	assert.NotContains(t, string(out), "citations_list")
+
+	// Re-unmarshal to confirm the citation survives the round trip.
+	var rt MessageContent
+	if err := json.Unmarshal(out, &rt); err != nil {
+		t.Fatalf("re-unmarshal error: %v", err)
+	}
+	assert.Len(t, rt.Citations, 1)
+	assert.Equal(t, "The grass is green.", rt.Citations[0].CitedText)
+	assert.Equal(t, CitationTypeCharLocation, rt.Citations[0].Type)
+}
+
+func TestMessageContentDocumentCitationsStillMarshal(t *testing.T) {
+	// Request-side document blocks must still emit DocumentCitations under
+	// the "citations" key.
+	doc := NewTextDocumentMessageContent("some text", "Title", "Context", true)
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	assert.Contains(t, string(out), `"citations":{"enabled":true}`)
+	assert.NotContains(t, string(out), "citations_list")
+}

--- a/message.go
+++ b/message.go
@@ -292,22 +292,59 @@ type MessageContent struct {
 
 // MarshalJSON implements custom JSON marshaling for MessageContent.
 //
-// MessageContent embeds several pointer structs (tool_use, server_tool_use,
-// tool_result, web_search_tool_result) that declare overlapping JSON field
-// names — for example both MessageContentToolResult and
-// MessageContentWebSearchToolResult define "tool_use_id" and "content", and
-// both MessageContentToolUse and MessageContentServerToolUse define "id",
-// "name" and "input". Go's encoding/json drops fields that are ambiguous across
-// embedded structs at the same depth, which would silently strip "tool_use_id",
-// "content", "id", "name" and "input" from the wire payload.
+// This does two things that plain struct marshaling can't:
 //
-// To produce a correct payload we marshal the base struct (which omits the
-// ambiguous fields) and then merge back the fields of whichever embedded tool
-// struct is actually populated. Blocks without an ambiguous embedded struct
-// (text, image, document, thinking, …) are marshaled exactly as before.
+//  1. Citations: the response-side Citations slice is stored under the
+//     non-API json tag "citations_list" (to avoid colliding with the
+//     request-side DocumentCitations field, which is tagged "citations").
+//     UnmarshalJSON maps the incoming API "citations" array onto Citations,
+//     but without this override, re-serializing cited assistant content
+//     would emit "citations_list" and silently drop the citations when
+//     echoed back to the API. This emits the response citations under the
+//     API key "citations". The response Citations slice and the request
+//     DocumentCitations are mutually exclusive in practice, so only one is
+//     ever surfaced under "citations".
+//
+//  2. Ambiguous embedded fields: MessageContent embeds several pointer
+//     structs (tool_use, server_tool_use, tool_result, web_search_tool_result)
+//     that declare overlapping JSON field names — for example both
+//     MessageContentToolResult and MessageContentWebSearchToolResult define
+//     "tool_use_id" and "content", and both MessageContentToolUse and
+//     MessageContentServerToolUse define "id", "name" and "input". Go's
+//     encoding/json drops fields that are ambiguous across embedded structs
+//     at the same depth, which would silently strip "tool_use_id", "content",
+//     "id", "name" and "input" from the wire payload.
+//
+// To produce a correct payload we first marshal the base struct with the
+// citations override applied (which still omits the ambiguous tool fields)
+// and then merge back the fields of whichever embedded tool struct is
+// actually populated. Blocks without an ambiguous embedded struct (text,
+// image, document, thinking, …) skip the merge step.
 func (m MessageContent) MarshalJSON() ([]byte, error) {
 	type Alias MessageContent
-	base, err := json.Marshal(Alias(m))
+	aux := struct {
+		Alias
+		// Citations surfaces either the response-side citations array or the
+		// request-side document citations object under the API key.
+		Citations interface{} `json:"citations,omitempty"`
+	}{
+		Alias: (Alias)(m),
+	}
+
+	// Suppress the alias-level citation fields:
+	//   - Alias.Citations is tagged "citations_list" (non-API key)
+	//   - Alias.DocumentCitations is tagged "citations" and would otherwise
+	//     conflict with the outer field.
+	aux.Alias.Citations = nil
+	aux.Alias.DocumentCitations = nil
+
+	if len(m.Citations) > 0 {
+		aux.Citations = m.Citations
+	} else if m.DocumentCitations != nil {
+		aux.Citations = m.DocumentCitations
+	}
+
+	base, err := json.Marshal(aux)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
\`MessageContent.Citations\` (response-side citations, populated by \`UnmarshalJSON\`) is tagged \`citations_list\` internally to avoid colliding with the request-side \`DocumentCitations\` field, which is tagged \`citations\`. Without a custom \`MarshalJSON\`, re-serializing cited assistant content (e.g. to echo it back in a multi-turn conversation) emitted \`citations_list\` and silently dropped the citations instead of sending them back under the API's \`citations\` key.

Adds a \`MarshalJSON\` that surfaces either the response \`Citations\` or the request \`DocumentCitations\` under the API key \`citations\" — the two are mutually exclusive in practice.

Added round-trip tests for both the response-citations case and the existing request-side document-citations case (to confirm it's unaffected).

Build and tests pass locally.