### PR TITLE
fix: only emit JSON schema properties for object types

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -29,7 +29,7 @@ type Definition struct {
 	// one element, where each element is unique. You will probably only use this with strings.
 	Enum []string `json:"enum,omitempty"`
 	// Properties describes the properties of an object, if the schema type is Object.
-	Properties map[string]Definition `json:"properties"`
+	Properties map[string]Definition `json:"properties,omitempty"`
 	// Required specifies which properties are required, if the schema type is Object.
 	Required []string `json:"required,omitempty"`
 	// Items specifies which data type an array contains, if the schema type is Array.
@@ -37,7 +37,9 @@ type Definition struct {
 }
 
 func (d Definition) MarshalJSON() ([]byte, error) {
-	if d.Properties == nil {
+	// Only object schemas carry a properties map. Forcing it onto scalars and
+	// array items previously emitted a spurious "properties":{} on every node.
+	if d.Type == Object && d.Properties == nil {
 		d.Properties = make(map[string]Definition)
 	}
 	type Alias Definition

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -17,7 +17,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with empty Definition",
 			def:  jsonschema.Definition{},
-			want: `{"properties":{}}`,
+			want: `{}`,
 		},
 		{
 			name: "Test with Definition properties set",
@@ -35,8 +35,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
    "description":"A string type",
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":"string"
       }
    }
 }`,
@@ -66,12 +65,10 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             }
          }
       }
@@ -114,23 +111,19 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             },
             "address":{
                "type":"object",
                "properties":{
                   "city":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   },
                   "country":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   }
                }
             }
@@ -155,15 +148,11 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 			want: `{
    "type":"array",
    "items":{
-      "type":"string",
-      "properties":{
-         
-      }
+      "type":"string"
    },
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":"string"
       }
    }
 }`,


### PR DESCRIPTION
\`Definition.MarshalJSON\` unconditionally defaulted \`Properties\` to an empty map when nil, which meant every non-object schema node (strings, integers, arrays, array \`items\`, etc.) emitted a spurious \`"properties":{}\` in the tool schema sent to the API.

Now \`properties\` is only forced/emitted for \`Type == Object\`, and the field is \`omitempty\` so it's dropped entirely when there's nothing to show.

Updated the existing marshal tests to reflect the corrected (smaller, more spec-correct) output.

Build and tests pass locally.