### PR TITLE
fix: decode errored batch results

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -118,8 +118,11 @@ func (c *Client) RetrieveBatch(
 }
 
 type BatchResultCore struct {
-	Type   ResultType       `json:"type"`
+	Type ResultType `json:"type"`
+	// Result holds the message for results with type "succeeded".
 	Result MessagesResponse `json:"message"`
+	// Error holds the error envelope for results with type "errored".
+	Error *ErrorResponse `json:"error,omitempty"`
 }
 
 type BatchResult struct {

--- a/batch_test.go
+++ b/batch_test.go
@@ -433,3 +433,26 @@ func forgeBatchResponse(batchId string) anthropic.BatchRespCore {
 		ResultsUrl:        nil,
 	}
 }
+
+func TestBatchResultErrored(t *testing.T) {
+	line := `{"custom_id":"req-1","result":{"type":"errored","error":{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}}}`
+
+	var parsed anthropic.BatchResult
+	if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if parsed.Result.Type != anthropic.ResultTypeErrored {
+		t.Fatalf("unexpected result type: %s", parsed.Result.Type)
+	}
+	if parsed.Result.Error == nil {
+		t.Fatalf("expected error envelope, got nil")
+	}
+	if parsed.Result.Error.Error == nil ||
+		parsed.Result.Error.Error.Type != anthropic.ErrTypeInvalidRequest {
+		t.Fatalf("unexpected error payload: %+v", parsed.Result.Error)
+	}
+	if parsed.Result.Error.Error.Message != "bad request" {
+		t.Fatalf("unexpected error message: %q", parsed.Result.Error.Error.Message)
+	}
+}


### PR DESCRIPTION
\`BatchResultCore\` only had a \`Result MessagesResponse\` field for the "message" payload, with no field for the error envelope the API sends when a batch result's \`type\` is \`"errored"\`. Those results decoded with a zero-value \`MessagesResponse\` and the actual error information was silently dropped.

Adds \`Error *ErrorResponse \`json:"error,omitempty"\`\` alongside the existing \`Result\` field so errored results are decodable.

Added a test unmarshaling an errored result line and asserting the error type/message survive.

**Verified against docs:** the [Retrieve Message Batch results reference](https://platform.claude.com/docs/en/api/retrieving-message-batch-results) documents `MessageBatchErroredResult` as `{ error: ErrorResponse, type: "errored" }`, where `ErrorResponse` is `{ type: "error", error: ErrorObject }`. This matches the existing `ErrorResponse` struct in `error.go` (`Type string`, `Error *APIError`) exactly, so the new field's shape lines up with the documented schema.

Build and tests pass locally.