### PR TITLE
Add Claude Sonnet 5 support, document model deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,18 +501,44 @@ Beta Version Identifier            | Code Constant                   | Descripti
 The following models are supported by go-anthropic.
 These models are also available for use on Google's Vertex AI platform as well.
 
-Model Name                     | Model String
--------------------------------|------------------------------
-ModelClaude2Dot0               | "claude-2.0"
-ModelClaude2Dot1               | "claude-2.1"
-ModelClaude3Opus20240229       | "claude-3-opus-20240229"
-ModelClaude3Sonnet20240229     | "claude-3-sonnet-20240229"
-ModelClaude3Dot5Sonnet20240620 | "claude-3-5-sonnet-20240620"
-ModelClaude3Dot5Sonnet20241022 | "claude-3-5-sonnet-20241022"
-ModelClaude3Dot5SonnetLatest   | "claude-3-5-sonnet-latest"
-ModelClaude3Haiku20240307      | "claude-3-haiku-20240307"
-ModelClaude3Dot5HaikuLatest    | "claude-3-5-haiku-latest"
-ModelClaude3Dot5Haiku20241022  | "claude-3-5-haiku-20241022"
+Deprecated and retired constants are kept for backwards compatibility (existing code keeps compiling) and are
+marked with Go `// Deprecated:` doc comments in [common.go](common.go); requests using a **Retired** model ID
+will fail against the Anthropic API. See [Anthropic's model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations)
+for the current, authoritative status.
+
+Model Name                     | Model String                    | Status
+--------------------------------|----------------------------------|------------------------------
+ModelClaude2Dot0                | "claude-2.0"                     | Retired (2025-07-21)
+ModelClaude2Dot1                | "claude-2.1"                     | Retired (2025-07-21)
+ModelClaude3Opus20240229        | "claude-3-opus-20240229"         | Retired (2026-01-05)
+ModelClaude3Sonnet20240229      | "claude-3-sonnet-20240229"       | Retired (2025-07-21)
+ModelClaude3Dot5Sonnet20240620  | "claude-3-5-sonnet-20240620"     | Retired (2025-10-28)
+ModelClaude3Dot5Sonnet20241022  | "claude-3-5-sonnet-20241022"     | Retired (2025-10-28)
+ModelClaude3Dot5SonnetLatest    | "claude-3-5-sonnet-latest"       | Retired (aliased a retired snapshot)
+ModelClaude3Haiku20240307       | "claude-3-haiku-20240307"        | Retired (2026-04-20)
+ModelClaude3Dot5HaikuLatest     | "claude-3-5-haiku-latest"        | Retired (aliased a retired snapshot)
+ModelClaude3Dot5Haiku20241022   | "claude-3-5-haiku-20241022"      | Retired (2026-02-19)
+ModelClaudeHaiku4Dot5           | "claude-haiku-4-5"               | Active
+ModelClaudeHaiku4Dot5V20251001  | "claude-haiku-4-5-20251001"      | Active
+ModelClaude3Dot7SonnetLatest    | "claude-3-7-sonnet-latest"       | Retired (aliased a retired snapshot)
+ModelClaude3Dot7Sonnet20250219  | "claude-3-7-sonnet-20250219"     | Retired (2026-02-19)
+ModelClaudeOpus4Dot0            | "claude-opus-4-0"                | Retired (aliased a retired snapshot)
+ModelClaudeOpus4V20250514       | "claude-opus-4-20250514"         | Retired (2026-06-15)
+ModelClaudeOpus4Dot1            | "claude-opus-4-1"                | Deprecated, retires 2026-08-05
+ModelClaudeOpus4Dot1V20250805   | "claude-opus-4-1-20250805"       | Deprecated, retires 2026-08-05
+ModelClaudeSonnet4Dot0          | "claude-sonnet-4-0"              | Retired (aliased a retired snapshot)
+ModelClaudeSonnet4V20250514     | "claude-sonnet-4-20250514"       | Retired (2026-06-15)
+ModelClaudeSonnet4Dot5          | "claude-sonnet-4-5"              | Active
+ModelClaudeSonnet4Dot5V20250929 | "claude-sonnet-4-5-20250929"     | Active
+ModelClaudeOpus4Dot5            | "claude-opus-4-5"                | Active
+ModelClaudeOpus4Dot5V20251101   | "claude-opus-4-5-20251101"       | Active
+ModelClaudeSonnet4Dot6          | "claude-sonnet-4-6"              | Active
+ModelClaudeOpus4Dot6            | "claude-opus-4-6"                | Active
+ModelClaudeOpus4Dot7            | "claude-opus-4-7"                | Active
+ModelClaudeOpus4Dot8            | "claude-opus-4-8"                | Active
+ModelClaudeSonnet5               | "claude-sonnet-5"                | Active
+ModelClaudeFable5                | "claude-fable-5"                 | Active
+ModelClaudeMythos5               | "claude-mythos-5"                | Active (Project Glasswing only)
 
 ### Other Enums
 Two exported enums are additionally provided:

--- a/common.go
+++ b/common.go
@@ -3,25 +3,43 @@ package anthropic
 type Model string
 
 const (
-	ModelClaude2Dot0                Model = "claude-2.0"
-	ModelClaude2Dot1                Model = "claude-2.1"
-	ModelClaude3Opus20240229        Model = "claude-3-opus-20240229"
-	ModelClaude3Sonnet20240229      Model = "claude-3-sonnet-20240229"
-	ModelClaude3Dot5Sonnet20240620  Model = "claude-3-5-sonnet-20240620"
-	ModelClaude3Dot5Sonnet20241022  Model = "claude-3-5-sonnet-20241022"
-	ModelClaude3Dot5SonnetLatest    Model = "claude-3-5-sonnet-latest"
-	ModelClaude3Haiku20240307       Model = "claude-3-haiku-20240307"
-	ModelClaude3Dot5HaikuLatest     Model = "claude-3-5-haiku-latest"
-	ModelClaude3Dot5Haiku20241022   Model = "claude-3-5-haiku-20241022"
-	ModelClaudeHaiku4Dot5           Model = "claude-haiku-4-5"
-	ModelClaudeHaiku4Dot5V20251001  Model = "claude-haiku-4-5-20251001"
-	ModelClaude3Dot7SonnetLatest    Model = "claude-3-7-sonnet-latest"
-	ModelClaude3Dot7Sonnet20250219  Model = "claude-3-7-sonnet-20250219"
-	ModelClaudeOpus4Dot0            Model = "claude-opus-4-0"
-	ModelClaudeOpus4V20250514       Model = "claude-opus-4-20250514"
-	ModelClaudeOpus4Dot1            Model = "claude-opus-4-1"
-	ModelClaudeOpus4Dot1V20250805   Model = "claude-opus-4-1-20250805"
-	ModelClaudeSonnet4Dot0          Model = "claude-sonnet-4-0"
+	// Deprecated: claude-2.0 was retired on July 21, 2025; requests now fail. Use ModelClaudeOpus4Dot8.
+	ModelClaude2Dot0 Model = "claude-2.0"
+	// Deprecated: claude-2.1 was retired on July 21, 2025; requests now fail. Use ModelClaudeOpus4Dot8.
+	ModelClaude2Dot1 Model = "claude-2.1"
+	// Deprecated: claude-3-opus-20240229 was retired on January 5, 2026; requests now fail. Use ModelClaudeOpus4Dot8.
+	ModelClaude3Opus20240229 Model = "claude-3-opus-20240229"
+	// Deprecated: claude-3-sonnet-20240229 was retired on July 21, 2025; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Sonnet20240229 Model = "claude-3-sonnet-20240229"
+	// Deprecated: claude-3-5-sonnet-20240620 was retired on October 28, 2025; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Dot5Sonnet20240620 Model = "claude-3-5-sonnet-20240620"
+	// Deprecated: claude-3-5-sonnet-20241022 was retired on October 28, 2025; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Dot5Sonnet20241022 Model = "claude-3-5-sonnet-20241022"
+	// Deprecated: the claude-3-5-sonnet-latest alias pointed at a now-retired Claude 3.5 Sonnet snapshot; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Dot5SonnetLatest Model = "claude-3-5-sonnet-latest"
+	// Deprecated: claude-3-haiku-20240307 was retired on April 20, 2026; requests now fail. Use ModelClaudeHaiku4Dot5.
+	ModelClaude3Haiku20240307 Model = "claude-3-haiku-20240307"
+	// Deprecated: the claude-3-5-haiku-latest alias pointed at a now-retired Claude 3.5 Haiku snapshot; requests now fail. Use ModelClaudeHaiku4Dot5.
+	ModelClaude3Dot5HaikuLatest Model = "claude-3-5-haiku-latest"
+	// Deprecated: claude-3-5-haiku-20241022 was retired on February 19, 2026; requests now fail. Use ModelClaudeHaiku4Dot5.
+	ModelClaude3Dot5Haiku20241022  Model = "claude-3-5-haiku-20241022"
+	ModelClaudeHaiku4Dot5          Model = "claude-haiku-4-5"
+	ModelClaudeHaiku4Dot5V20251001 Model = "claude-haiku-4-5-20251001"
+	// Deprecated: the claude-3-7-sonnet-latest alias pointed at a now-retired Claude 3.7 Sonnet snapshot; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Dot7SonnetLatest Model = "claude-3-7-sonnet-latest"
+	// Deprecated: claude-3-7-sonnet-20250219 was retired on February 19, 2026; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaude3Dot7Sonnet20250219 Model = "claude-3-7-sonnet-20250219"
+	// Deprecated: the claude-opus-4-0 alias pointed at claude-opus-4-20250514, retired June 15, 2026; requests now fail. Use ModelClaudeOpus4Dot8.
+	ModelClaudeOpus4Dot0 Model = "claude-opus-4-0"
+	// Deprecated: claude-opus-4-20250514 was retired on June 15, 2026; requests now fail. Use ModelClaudeOpus4Dot8.
+	ModelClaudeOpus4V20250514 Model = "claude-opus-4-20250514"
+	// Deprecated: claude-opus-4-1 is scheduled to retire on August 5, 2026. Use ModelClaudeOpus4Dot8.
+	ModelClaudeOpus4Dot1 Model = "claude-opus-4-1"
+	// Deprecated: claude-opus-4-1-20250805 is scheduled to retire on August 5, 2026. Use ModelClaudeOpus4Dot8.
+	ModelClaudeOpus4Dot1V20250805 Model = "claude-opus-4-1-20250805"
+	// Deprecated: the claude-sonnet-4-0 alias pointed at claude-sonnet-4-20250514, retired June 15, 2026; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
+	ModelClaudeSonnet4Dot0 Model = "claude-sonnet-4-0"
+	// Deprecated: claude-sonnet-4-20250514 was retired on June 15, 2026; requests now fail. Use ModelClaudeSonnet4Dot6 or ModelClaudeSonnet5.
 	ModelClaudeSonnet4V20250514     Model = "claude-sonnet-4-20250514"
 	ModelClaudeSonnet4Dot5          Model = "claude-sonnet-4-5"
 	ModelClaudeSonnet4Dot5V20250929 Model = "claude-sonnet-4-5-20250929"
@@ -31,7 +49,9 @@ const (
 	ModelClaudeOpus4Dot6            Model = "claude-opus-4-6"
 	ModelClaudeOpus4Dot7            Model = "claude-opus-4-7"
 	ModelClaudeOpus4Dot8            Model = "claude-opus-4-8"
+	ModelClaudeSonnet5              Model = "claude-sonnet-5"
 	ModelClaudeFable5               Model = "claude-fable-5"
+	ModelClaudeMythos5              Model = "claude-mythos-5"
 )
 
 type ChatRole string
@@ -77,8 +97,12 @@ func (m Model) asVertexModel() string {
 		return "claude-opus-4-7"
 	case ModelClaudeOpus4Dot8:
 		return "claude-opus-4-8"
+	case ModelClaudeSonnet5:
+		return "claude-sonnet-5"
 	case ModelClaudeFable5:
 		return "claude-fable-5"
+	case ModelClaudeMythos5:
+		return "claude-mythos-5"
 	default:
 		return string(m)
 	}


### PR DESCRIPTION
## Summary
- Add `ModelClaudeSonnet5` (`claude-sonnet-5`) and `ModelClaudeMythos5` (`claude-mythos-5`) constants, wired into the Vertex AI model mapping, to bring the model list in line with Anthropic's current lineup.
- Mark model constants Anthropic has retired or scheduled for retirement with Go `// Deprecated:` doc comments (matching the existing convention in `message.go`) instead of removing them, so existing consumer code keeps compiling. Per Anthropic's [model deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations):
  - Retired (requests now fail): `claude-2.0`, `claude-2.1`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-5-sonnet-20240620`/`-20241022` (+ `-latest` alias), `claude-3-haiku-20240307`, `claude-3-5-haiku-20241022` (+ `-latest` alias), `claude-3-7-sonnet-20250219` (+ `-latest` alias), `claude-opus-4-20250514` (+ `claude-opus-4-0` alias), `claude-sonnet-4-20250514` (+ `claude-sonnet-4-0` alias).
  - Deprecated, still functional: `claude-opus-4-1`/`claude-opus-4-1-20250805`, retiring 2026-08-05.
- Refresh the README's "Supported models" table, which had been stale since the Claude 3.5 generation, and add a Status column (Active / Deprecated / Retired) so this is visible without reading source.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` / `golines -l .` clean