### PR TITLE
fix: ignore SSE comments and unknown event types in streams

### DIFF
--- a/complete_stream.go
+++ b/complete_stream.go
@@ -73,6 +73,11 @@ func (c *Client) CreateCompleteStream(
 		if len(noSpaceLine) == 0 {
 			continue
 		}
+		// SSE comment lines (proxy keep-alives) must be ignored without
+		// counting against the empty-message budget.
+		if bytes.HasPrefix(noSpaceLine, commentPrefix) {
+			continue
+		}
 		if bytes.HasPrefix(noSpaceLine, eventPrefix) {
 			event = bytes.TrimSpace(bytes.TrimPrefix(noSpaceLine, eventPrefix))
 			continue
@@ -82,6 +87,9 @@ func (c *Client) CreateCompleteStream(
 				data      = bytes.TrimPrefix(noSpaceLine, dataPrefix)
 				eventType = CompleteEvent(event)
 			)
+			// A genuine SSE data event was received; reset the lifetime
+			// empty-message counter so healthy long streams are never aborted.
+			emptyMessageCount = 0
 			switch eventType {
 			case CompleteEventError:
 				var d ErrorResponse
@@ -117,6 +125,10 @@ func (c *Client) CreateCompleteStream(
 				response.StopReason = d.StopReason
 				response.Model = d.Model
 				response.Completion += d.Completion
+				continue
+			default:
+				// Unknown or future event type. Per the SSE spec it must be
+				// ignored rather than counted against the empty-message budget.
 				continue
 			}
 		}

--- a/message_stream.go
+++ b/message_stream.go
@@ -12,8 +12,11 @@ import (
 )
 
 var (
-	eventPrefix                   = []byte("event:")
-	dataPrefix                    = []byte("data:")
+	eventPrefix = []byte("event:")
+	dataPrefix  = []byte("data:")
+	// commentPrefix marks an SSE comment line (e.g. proxy keep-alives). Per the
+	// SSE spec these must be ignored.
+	commentPrefix                 = []byte(":")
 	ErrTooManyEmptyStreamMessages = errors.New("stream has sent too many empty messages")
 )
 
@@ -184,6 +187,11 @@ func (c *Client) CreateMessagesStream(
 		if len(noSpaceLine) == 0 {
 			continue
 		}
+		// SSE comment lines (proxy keep-alives) must be ignored without
+		// counting against the empty-message budget.
+		if bytes.HasPrefix(noSpaceLine, commentPrefix) {
+			continue
+		}
 		if bytes.HasPrefix(noSpaceLine, eventPrefix) {
 			event = bytes.TrimSpace(bytes.TrimPrefix(noSpaceLine, eventPrefix))
 			continue
@@ -193,6 +201,9 @@ func (c *Client) CreateMessagesStream(
 				data      = bytes.TrimPrefix(noSpaceLine, dataPrefix)
 				eventType = MessagesEvent(event)
 			)
+			// A genuine SSE data event was received; reset the lifetime
+			// empty-message counter so healthy long streams are never aborted.
+			emptyMessageCount = 0
 			switch eventType {
 			case MessagesEventError:
 				var eventData ErrorResponse
@@ -314,6 +325,10 @@ func (c *Client) CreateMessagesStream(
 				if request.OnMessageStop != nil {
 					request.OnMessageStop(d)
 				}
+				continue
+			default:
+				// Unknown or future event type. Per the SSE spec it must be
+				// ignored rather than counted against the empty-message budget.
 				continue
 			}
 		}

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -861,6 +861,87 @@ func handlerMessagesStreamToolUseWithoutParameters(w http.ResponseWriter, r *htt
 	_, _ = w.Write(dataBytes)
 }
 
+func TestCreateMessagesStreamIgnoresCommentsAndUnknownEvents(t *testing.T) {
+	server := test.NewTestServer()
+	server.RegisterHandler("/v1/messages", handlerMessagesStreamCommentsAndUnknownEvents)
+
+	ts := server.AnthropicTestServer()
+	ts.Start()
+	defer ts.Close()
+
+	baseUrl := ts.URL + "/v1"
+	// A small limit ensures the test fails if comment/unknown lines were
+	// counted against the empty-message budget.
+	client := anthropic.NewClient(
+		test.GetTestToken(),
+		anthropic.WithBaseURL(baseUrl),
+		anthropic.WithEmptyMessagesLimit(5),
+	)
+
+	var received string
+	_, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
+		MessagesRequest: anthropic.MessagesRequest{
+			Model: anthropic.ModelClaude3Haiku20240307,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("What is your name?"),
+			},
+			MaxTokens: 1000,
+		},
+		OnContentBlockDelta: func(data anthropic.MessagesEventContentBlockDeltaData) {
+			received += data.Delta.GetText()
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessagesStream unexpected error: %s", err)
+	}
+	if received != "hello" {
+		t.Fatalf("expected content %q, got %q", "hello", received)
+	}
+}
+
+func handlerMessagesStreamCommentsAndUnknownEvents(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	var dataBytes []byte
+
+	dataBytes = append(dataBytes, []byte("event: message_start\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"message_start","message":{"id":"1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"output_tokens":1}}}`+"\n\n",
+		)...)
+
+	dataBytes = append(dataBytes, []byte("event: content_block_start\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n",
+		)...)
+
+	// Many SSE comment lines (proxy keep-alives) and unknown/future event
+	// types, far exceeding the empty-message limit of 5.
+	for i := 0; i < 50; i++ {
+		dataBytes = append(dataBytes, []byte(": keep-alive\n\n")...)
+		dataBytes = append(dataBytes, []byte("event: some_future_event\n")...)
+		dataBytes = append(dataBytes, []byte(`data: {"type":"some_future_event"}`+"\n\n")...)
+	}
+
+	dataBytes = append(dataBytes, []byte("event: content_block_delta\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`+"\n\n",
+		)...)
+
+	dataBytes = append(dataBytes, []byte("event: content_block_stop\n")...)
+	dataBytes = append(dataBytes, []byte(`data: {"type":"content_block_stop","index":0}`+"\n\n")...)
+
+	dataBytes = append(dataBytes, []byte("event: message_stop\n")...)
+	dataBytes = append(dataBytes, []byte(`data: {"type":"message_stop"}`+"\n\n")...)
+
+	_, _ = w.Write(dataBytes)
+}
+
 func handlerMessagesStreamEmptyMessages(numEmptyMessages int, payload string) test.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, err := getRequest[anthropic.MessagesRequest](r)


### PR DESCRIPTION
## Problem

The streaming decoders in `CreateMessagesStream` (and `CreateCompleteStream`) `switch` on the SSE event type with **no `default` case**. Any line that is not a recognized `event:`/`data:` pair — including:

- **SSE comment lines** (a line beginning with `:`, used by proxies/load balancers as keep-alives), and
- **unknown / future event types** whose `data:` payload doesn't match a known case,

falls through to `emptyMessageCount++`. Because that counter is never reset, a long-lived stream that accumulates more than `EmptyMessagesLimit` such lines is aborted with `ErrTooManyEmptyStreamMessages`, even though the stream is perfectly healthy.

## Why this is a real divergence

The Anthropic streaming docs explicitly require clients to tolerate event types they don't recognize:

> "In accordance with the [versioning policy](https://platform.claude.com/docs/en/api/versioning), new event types may be added, and your code should handle unknown event types gracefully."
> — https://platform.claude.com/docs/en/docs/build-with-claude/streaming (§ Event types)

and note that keep-alive traffic is expected:

> "Event streams may also include any number of `ping` events." / "There may be `ping` events dispersed throughout the response as well."

SSE comment lines (`:`-prefixed) are mandated to be ignored by the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) and are commonly injected by intermediary proxies as keep-alives.

## Fix

- Ignore SSE comment lines (`:` prefix) without counting them against the empty-message budget.
- Add a `default:` case to the event `switch` so unknown/future event types are skipped gracefully rather than counted as empty.
- Reset `emptyMessageCount` to 0 whenever a genuine data event is processed, so healthy long streams are never aborted by sparse unrecognized lines.

Applied symmetrically to both `message_stream.go` and `complete_stream.go`.

## Tests

Adds coverage asserting that streams containing comment lines and unknown event types complete successfully rather than erroring with `ErrTooManyEmptyStreamMessages`. `go test ./...` passes.
