### PR TITLE
fix: merge server tool usage and cache creation from message_delta

### DIFF
--- a/message_stream.go
+++ b/message_stream.go
@@ -305,6 +305,15 @@ func (c *Client) CreateMessagesStream(
 				response.StopReason = d.Delta.StopReason
 				response.StopSequence = d.Delta.StopSequence
 				response.Usage.OutputTokens = d.Usage.OutputTokens
+				// The final message_delta also reports cumulative server tool
+				// usage (e.g. web-search request counts) and cache creation
+				// details that are only present here; merge them when set.
+				if d.Usage.ServerToolUse != nil {
+					response.Usage.ServerToolUse = d.Usage.ServerToolUse
+				}
+				if d.Usage.CacheCreation != (MessageUsageCacheCreation{}) {
+					response.Usage.CacheCreation = d.Usage.CacheCreation
+				}
 				continue
 			case MessagesEventMessageStop:
 				var d MessagesEventMessageStopData

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -617,7 +617,10 @@ func TestCreateMessagesStreamMergesServerToolUsage(t *testing.T) {
 		t.Fatalf("expected Usage.ServerToolUse to be populated, got nil")
 	}
 	if resp.Usage.ServerToolUse.WebSearchRequests != 3 {
-		t.Fatalf("expected 3 web search requests, got %d", resp.Usage.ServerToolUse.WebSearchRequests)
+		t.Fatalf(
+			"expected 3 web search requests, got %d",
+			resp.Usage.ServerToolUse.WebSearchRequests,
+		)
 	}
 }
 

--- a/message_stream_test.go
+++ b/message_stream_test.go
@@ -586,6 +586,66 @@ func handlerMessagesStream(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(dataBytes)
 }
 
+func TestCreateMessagesStreamMergesServerToolUsage(t *testing.T) {
+	server := test.NewTestServer()
+	server.RegisterHandler("/v1/messages", handlerMessagesStreamServerToolUse)
+
+	ts := server.AnthropicTestServer()
+	ts.Start()
+	defer ts.Close()
+
+	baseUrl := ts.URL + "/v1"
+	client := anthropic.NewClient(
+		test.GetTestToken(),
+		anthropic.WithBaseURL(baseUrl),
+	)
+
+	resp, err := client.CreateMessagesStream(context.Background(), anthropic.MessagesStreamRequest{
+		MessagesRequest: anthropic.MessagesRequest{
+			Model: anthropic.ModelClaude3Haiku20240307,
+			Messages: []anthropic.Message{
+				anthropic.NewUserTextMessage("Search the web."),
+			},
+			MaxTokens: 1000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessagesStream error: %s", err)
+	}
+
+	if resp.Usage.ServerToolUse == nil {
+		t.Fatalf("expected Usage.ServerToolUse to be populated, got nil")
+	}
+	if resp.Usage.ServerToolUse.WebSearchRequests != 3 {
+		t.Fatalf("expected 3 web search requests, got %d", resp.Usage.ServerToolUse.WebSearchRequests)
+	}
+}
+
+func handlerMessagesStreamServerToolUse(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+
+	var dataBytes []byte
+
+	dataBytes = append(dataBytes, []byte("event: message_start\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"message_start","message":{"id":"1","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14,"output_tokens":1}}}`+"\n\n",
+		)...)
+
+	dataBytes = append(dataBytes, []byte("event: message_delta\n")...)
+	dataBytes = append(
+		dataBytes,
+		[]byte(
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":9,"server_tool_use":{"web_search_requests":3}}}`+"\n\n",
+		)...)
+
+	dataBytes = append(dataBytes, []byte("event: message_stop\n")...)
+	dataBytes = append(dataBytes, []byte(`data: {"type":"message_stop"}`+"\n\n")...)
+
+	_, _ = w.Write(dataBytes)
+}
+
 func handlerMessagesStreamSparseContentBlockIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 


### PR DESCRIPTION
## Problem

When handling the `message_delta` event in `CreateMessagesStream`, the decoder copies only `OutputTokens` from the event's `usage` field:

```go
response.Usage.OutputTokens = d.Usage.OutputTokens
```

The final `message_delta` is the **only** place the API reports cumulative `server_tool_use` (e.g. `web_search_requests`) and `cache_creation` details. Because we drop them here, the assembled `response.Usage.ServerToolUse` is always `nil` and `CacheCreation` is always zero for streamed responses — a silent loss of billing/metrics data that is present on the equivalent non-streamed call.

## Why this is a real divergence

The Anthropic streaming docs state the `message_delta` usage is cumulative:

> "The token counts shown in the `usage` field of the `message_delta` event are *cumulative*."
> — https://platform.claude.com/docs/en/docs/build-with-claude/streaming

and the documented web-search streaming example shows `server_tool_use` arriving on `message_delta`:

```
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},
       "usage":{"input_tokens":10682,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,
                "output_tokens":510,"server_tool_use":{"web_search_requests":1}}}
```

Both `ServerToolUse *ServerToolUsage` and `CacheCreation MessageUsageCacheCreation` already exist on `MessagesUsage`; they were simply never merged from `message_delta`.

## Fix

In the `MessagesEventMessageDelta` case, merge the server-tool usage and cache-creation details from the delta when set:

```go
if d.Usage.ServerToolUse != nil {
    response.Usage.ServerToolUse = d.Usage.ServerToolUse
}
if d.Usage.CacheCreation != (MessageUsageCacheCreation{}) {
    response.Usage.CacheCreation = d.Usage.CacheCreation
}
```

Guarded so absent fields never clobber values already accumulated from `message_start`.

## Tests

Adds a streamed-web-search case asserting `response.Usage.ServerToolUse.WebSearchRequests` is populated after the stream completes. `go test ./...` passes.
