### PR TITLE
fix: make combined rate-limit tokens-* headers optional

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -580,7 +580,9 @@ func TestMessagesRateLimitHeaders(t *testing.T) {
 		})
 	}
 
-	t.Run("returns error for missing rate limit headers", func(t *testing.T) {
+	t.Run("no error for missing rate limit headers", func(t *testing.T) {
+		// All rate limit headers (including the combined tokens-* headers) are
+		// optional, so a response that omits them must not produce an error.
 		invalidHeaders := map[string]string{}
 		resp, err := getRespWithHeaders(invalidHeaders)
 		if err != nil {
@@ -588,8 +590,8 @@ func TestMessagesRateLimitHeaders(t *testing.T) {
 		}
 
 		_, err = resp.GetRateLimitHeaders()
-		if err == nil {
-			t.Fatal("expected error, got nil")
+		if err != nil {
+			t.Fatalf("expected no error for missing rate limit headers, got: %v", err)
 		}
 	})
 }

--- a/ratelimit_headers.go
+++ b/ratelimit_headers.go
@@ -88,9 +88,12 @@ func newRateLimitHeaders(h http.Header) (RateLimitHeaders, error) {
 	headers.RequestsRemaining = parseIntHeader(requestsRemaining, false)
 	headers.RequestsReset = parseTimeHeader(requestsReset, false)
 
-	headers.TokensLimit = parseIntHeader(tokensLimit, true)
-	headers.TokensRemaining = parseIntHeader(tokensRemaining, true)
-	headers.TokensReset = parseTimeHeader(tokensReset, true)
+	// The combined tokens-* headers are omitted on count_tokens, batch, and
+	// split-token responses, so they must be optional like the others;
+	// otherwise GetRateLimitHeaders errors on otherwise-valid responses.
+	headers.TokensLimit = parseIntHeader(tokensLimit, false)
+	headers.TokensRemaining = parseIntHeader(tokensRemaining, false)
+	headers.TokensReset = parseTimeHeader(tokensReset, false)
 
 	headers.InputTokensLimit = parseIntHeader(inputTokensLimit, false)
 	headers.InputTokensRemaining = parseIntHeader(inputTokensRemaining, false)

--- a/ratelimit_headers_test.go
+++ b/ratelimit_headers_test.go
@@ -1,0 +1,25 @@
+package anthropic
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewRateLimitHeadersTokensOptional(t *testing.T) {
+	// A valid response (e.g. count_tokens / batch / split-token) that omits the
+	// combined anthropic-ratelimit-tokens-* headers must not produce an error.
+	h := http.Header{}
+	h.Set("anthropic-ratelimit-requests-limit", "1000")
+	h.Set("anthropic-ratelimit-requests-remaining", "999")
+	h.Set("anthropic-ratelimit-requests-reset", "2022-01-01T00:00:00Z")
+	h.Set("anthropic-ratelimit-input-tokens-limit", "2000")
+	h.Set("anthropic-ratelimit-output-tokens-limit", "3000")
+
+	headers, err := newRateLimitHeaders(h)
+	if err != nil {
+		t.Fatalf("expected no error when tokens-* headers are absent, got: %s", err)
+	}
+	if headers.RequestsLimit != 1000 {
+		t.Fatalf("expected RequestsLimit 1000, got %d", headers.RequestsLimit)
+	}
+}


### PR DESCRIPTION
## Problem

`newRateLimitHeaders` parses the combined `anthropic-ratelimit-tokens-*` headers as **required**:

```go
headers.TokensLimit     = parseIntHeader(tokensLimit, true)
headers.TokensRemaining = parseIntHeader(tokensRemaining, true)
headers.TokensReset     = parseTimeHeader(tokensReset, true)
```

When a header is required and absent/unparseable, `parseIntHeader` appends an error and `newRateLimitHeaders` returns a non-nil error — so `GetRateLimitHeaders` fails on otherwise-valid responses that don't carry the combined `tokens-*` set. This is inconsistent with the sibling `input-tokens-*` and `output-tokens-*` headers, which are already parsed as optional (`false`).

## Why this is a real divergence

Per the Anthropic rate-limits docs, the combined `anthropic-ratelimit-tokens-*` headers are **conditionally present**, reflecting whichever limit is most restrictive:

> "The `anthropic-ratelimit-tokens-*` headers display the values for the most restrictive limit currently in effect ... If Workspace limits do not apply, the headers will return the total tokens remaining, where total is the sum of input and output tokens."
> — https://platform.claude.com/docs/en/api/rate-limits (§ Response headers)

The docs list the split `anthropic-ratelimit-input-tokens-*` / `anthropic-ratelimit-output-tokens-*` headers alongside the combined set. In practice current models are limited by ITPM/OTPM (the split headers), and endpoints such as `count_tokens` and the Message Batches API don't return the combined `tokens-*` set at all. None of these token headers is guaranteed, so requiring the combined set is incorrect.

## Fix

Parse the combined `tokens-*` headers as optional, matching every other token header:

```go
headers.TokensLimit     = parseIntHeader(tokensLimit, false)
headers.TokensRemaining = parseIntHeader(tokensRemaining, false)
headers.TokensReset     = parseTimeHeader(tokensReset, false)
```

Absent headers now yield the sentinel (`-1` / zero time) like the others instead of producing an error.

## Tests

Adds a case asserting `GetRateLimitHeaders` succeeds (no error) on a response that omits the combined `tokens-*` headers but provides the split input/output token headers. `go test ./...` passes.
