### PR TITLE
fix: avoid double slash in fullURL for trailing-slash BaseURL

### DIFF
--- a/defaultadapter.go
+++ b/defaultadapter.go
@@ -1,8 +1,8 @@
 package anthropic
 
 import (
-	"fmt"
 	"net/http"
+	"strings"
 )
 
 var _ ClientAdapter = (*DefaultAdapter)(nil)
@@ -15,8 +15,9 @@ func (v *DefaultAdapter) TranslateError(resp *http.Response, body []byte) (error
 }
 
 func (v *DefaultAdapter) fullURL(baseUrl string, suffix string) string {
-	// replace the first slash with a colon
-	return fmt.Sprintf("%s%s", baseUrl, suffix)
+	// Trim a trailing slash so a BaseURL ending in "/" doesn't yield a double
+	// slash (e.g. ".../v1//messages"). suffix always begins with "/".
+	return strings.TrimRight(baseUrl, "/") + suffix
 }
 
 func (v *DefaultAdapter) PrepareRequest(

--- a/defaultadapter_test.go
+++ b/defaultadapter_test.go
@@ -1,0 +1,42 @@
+package anthropic
+
+import "testing"
+
+func TestDefaultAdapterFullURL(t *testing.T) {
+	adapter := &DefaultAdapter{}
+
+	tests := []struct {
+		name    string
+		baseURL string
+		suffix  string
+		want    string
+	}{
+		{
+			name:    "no trailing slash",
+			baseURL: "https://api.anthropic.com/v1",
+			suffix:  "/messages",
+			want:    "https://api.anthropic.com/v1/messages",
+		},
+		{
+			name:    "trailing slash",
+			baseURL: "https://api.anthropic.com/v1/",
+			suffix:  "/messages",
+			want:    "https://api.anthropic.com/v1/messages",
+		},
+		{
+			name:    "multiple trailing slashes",
+			baseURL: "https://api.anthropic.com/v1///",
+			suffix:  "/messages",
+			want:    "https://api.anthropic.com/v1/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := adapter.fullURL(tt.baseURL, tt.suffix)
+			if got != tt.want {
+				t.Fatalf("fullURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`DefaultAdapter.fullURL` concatenated `BaseURL` and the request suffix directly:

```go
// replace the first slash with a colon   <- stale/incorrect comment
return fmt.Sprintf("%s%s", baseUrl, suffix)
```

Every request suffix begins with `/` (`/messages`, `/complete`, `/messages/count_tokens`, `/messages/batches`, …). So if a caller configures a `BaseURL` that ends in `/` — common for corporate proxies and gateways, e.g. `WithBaseURL("https://gateway.internal/anthropic/v1/")` — the result is a doubled slash: `https://gateway.internal/anthropic/v1//messages`. Strict gateways reject or misroute the `//` path, producing 404s.

The default `BaseURL` (`https://api.anthropic.com/v1`) has no trailing slash, so the stock configuration is unaffected — this only bites custom base URLs.

> Note: this is an internal URL-join bug rather than a payload/schema divergence, so there's no specific Anthropic doc reference. The stale comment ("replace the first slash with a colon") also no longer described the code.

## Fix

Trim a trailing slash from the base before appending the (always slash-prefixed) suffix:

```go
return strings.TrimRight(baseUrl, "/") + suffix
```

Idempotent for base URLs without a trailing slash, so existing behavior is unchanged.

## Tests

Adds cases covering `BaseURL` with and without a trailing slash, asserting exactly one slash joins the segments. `go test ./...` passes.
