### PR TITLE
fix: keep model omitempty so Vertex/Bedrock omit it from the request body

### DIFF
--- a/message.go
+++ b/message.go
@@ -89,7 +89,12 @@ type DocumentCitations struct {
 }
 
 type MessagesRequest struct {
-	Model            Model     `json:"model"`
+	// Model is required by the direct Anthropic API, but on Vertex AI and
+	// Bedrock the model is carried in the URL and MUST NOT appear in the body.
+	// Those adapters blank it via SetAnthropicVersion/SetModel, so it must stay
+	// omitempty — otherwise an empty "model" leaks into the body and Vertex
+	// rejects the request with `model: Extra inputs are not permitted`.
+	Model            Model     `json:"model,omitempty"`
 	AnthropicVersion string    `json:"anthropic_version,omitempty"`
 	Messages         []Message `json:"messages"`
 	MaxTokens        int       `json:"max_tokens"`

--- a/vertex_model_body_test.go
+++ b/vertex_model_body_test.go
@@ -1,0 +1,70 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestVertexRequestOmitsModelFromBody is a regression test for the Vertex AI
+// (and Bedrock) request path. On those platforms the model is carried in the
+// URL and MUST NOT appear in the request body; the adapters strip it by setting
+// Model to "" (Vertex does this inside SetAnthropicVersion). If the "model"
+// field is not omitempty, the blanked model serializes as `"model":""` and
+// Vertex rejects the request with:
+//
+//	model: Extra inputs are not permitted
+//
+// See PR #117, which removed omitempty and regressed this behavior.
+func TestVertexRequestOmitsModelFromBody(t *testing.T) {
+	req := MessagesRequest{
+		Model:     ModelClaudeOpus4Dot6,
+		MaxTokens: 1024,
+		Messages: []Message{
+			NewUserTextMessage("hello"),
+		},
+	}
+
+	// Exactly what VertexAdapter.PrepareRequest does before the body is marshalled.
+	req.SetAnthropicVersion(APIVersionVertex20231016)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if strings.Contains(string(body), `"model"`) {
+		t.Fatalf("Vertex body must not contain a \"model\" field, got: %s", body)
+	}
+
+	// max_tokens is a valid Vertex body field and must still be present.
+	if !strings.Contains(string(body), `"max_tokens"`) {
+		t.Fatalf("body must retain \"max_tokens\", got: %s", body)
+	}
+
+	// anthropic_version must be injected for the Vertex path.
+	if !strings.Contains(string(body), `"anthropic_version":"vertex-2023-10-16"`) {
+		t.Fatalf("body must carry anthropic_version, got: %s", body)
+	}
+}
+
+// TestDirectRequestKeepsModelInBody guards the other direction: on the direct
+// Anthropic API the model is required in the body and must always be sent.
+func TestDirectRequestKeepsModelInBody(t *testing.T) {
+	req := MessagesRequest{
+		Model:     ModelClaudeOpus4Dot6,
+		MaxTokens: 1024,
+		Messages: []Message{
+			NewUserTextMessage("hello"),
+		},
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !strings.Contains(string(body), `"model":"claude-opus-4-6"`) {
+		t.Fatalf("direct API body must contain the model, got: %s", body)
+	}
+}


### PR DESCRIPTION
## Prod-breaking regression on Vertex AI (and Bedrock)

Requests that previously worked now fail on Vertex with:

```
error, status code: 400, message: vertex api error code: 0, status: ,
message: model: Extra inputs are not permitted
```

### Root cause

On Vertex AI the **model is carried in the URL, not the request body** — the body must not contain a `model` field (see https://platform.claude.com/docs/en/api/claude-on-vertex-ai). The SDK enforces this by blanking the model in `MessagesRequest.SetAnthropicVersion`, which the Vertex adapter calls before marshalling:

```go
func (m *MessagesRequest) SetAnthropicVersion(version APIVersion) {
    m.AnthropicVersion = string(version)
    m.Model = ""   // model goes in the URL on Vertex
}
```

This relied on the `Model` field being `json:"model,omitempty"` so the blanked value was dropped from the body. **PR #117** (`fix: remove omitempty from required fields Model and MaxTokens`) changed the tag to `json:"model"`, so the stripped model now serializes as `"model":""`:

```json
{"model":"","anthropic_version":"vertex-2023-10-16","messages":[...],"max_tokens":1024}
```

Vertex's request schema does not allow a `model` field, so it rejects the extra input. This breaks **every** Vertex `messages`/streaming call on the latest release.

### Fix

Restore `,omitempty` on `Model` only:

```go
Model Model `json:"model,omitempty"`
```

`MaxTokens` keeps its non-`omitempty` tag from #117 — that half is correct for the direct API and unaffected on Vertex (`max_tokens` is a valid, required body field there). I verified `Model` is the *only* field any adapter blanks-to-empty, that only `MessagesRequest` implements `VertexAISupport`, and that only `/messages` is routed to Vertex — so there is no sibling leak. The Bedrock adapter (separate branch) does the same `SetModel("")` strip and benefits from this fix as well.

### Tests

Adds `vertex_model_body_test.go` covering both directions:
- **Vertex path** — after `SetAnthropicVersion`, the marshalled body contains no `model` field (and still carries `max_tokens` + `anthropic_version`).
- **Direct path** — the body still contains `"model":"claude-opus-4-6"`.

`go test ./...`, `go vet ./...`, and `golines --dry-run .` all pass.

Regression from #117.
